### PR TITLE
remove schedule trigger for e2e merge group PR workflows

### DIFF
--- a/.github/workflows/arm-bicep-e2e-PR-v2.yaml
+++ b/.github/workflows/arm-bicep-e2e-PR-v2.yaml
@@ -1,16 +1,13 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
-# Terraform Provider testing workflow.
+
 name: 🧪 v2-arm-bicep-e2e
 
-# This GitHub action runs your tests before merging a pull request via merge groups
+# This workflow jobs never run. arm-bicep-e2e-v2.yaml has the arm / bicep e2e workflow which gets executed when PR is added to a merge queue, before merge to main.
+# This workflow is created as a workaround, as mentioned in the discussion linked below. 
 # Merge Group Discussions: https://github.com/orgs/community/discussions/51120
 on:
   pull_request:
-  workflow_dispatch:
-
-  schedule:
-    - cron: '0 21 * * *'
 
 permissions:
   id-token: write
@@ -21,52 +18,8 @@ jobs:
     if: false # https://github.com/orgs/community/discussions/51120
     name: 🧪 Run ARM Bicep e2e Tests
     runs-on: ubuntu-24.04
-    env:
-      MPF_SUBSCRIPTIONID: ${{ secrets.MPF_SUBSCRIPTIONID }}
-      MPF_TENANTID: ${{ secrets.MPF_TENANTID }}
-      MPF_SPCLIENTID: ${{ secrets.MPF_SPCLIENTID }}
-      MPF_SPCLIENTSECRET: ${{ secrets.MPF_SPCLIENTSECRET }}
-      MPF_SPOBJECTID: ${{ secrets.MPF_SPOBJECTID }}
-    permissions:
-      contents: read
-      pull-requests: write
-      checks: write
-      id-token: write
     steps:
       - name: ⤵️ Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-
-      - name: 🚧 Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: 🚧 Setup Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
-        with:
-          repo-token: ${{ github.token }}
-
-      - name: 🔀 Download Go dependencies
-        run: task deps:download
-
-      - name: 🔨 Setup Test tools
-        run: task test:tools
-
-      - name: Install Bicep
-        run: |
-          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
-          chmod +x ./bicep
-          sudo mv ./bicep /usr/local/bin/bicep
-
-      - name: 'Az CLI login - federated'
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_OID_CLIENT_ID }}
-          tenant-id: ${{ secrets.MPF_TENANTID }}
-          subscription-id: ${{ secrets.MPF_SUBSCRIPTIONID }}
-
-      - name: 🧪 Run ARM Bicep E2E Tests
-        run: task teste2e:armbicep

--- a/.github/workflows/arm-bicep-e2e-v2.yaml
+++ b/.github/workflows/arm-bicep-e2e-v2.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
-# Terraform Provider testing workflow.
+
 name: 🧪 v2-arm-bicep-e2e
 
 # This GitHub action runs your tests before merging a pull request via merge groups

--- a/.github/workflows/terraform-e2e-PR-v2.yaml
+++ b/.github/workflows/terraform-e2e-PR-v2.yaml
@@ -3,13 +3,11 @@
 # Terraform Provider testing workflow.
 name: 🧪 v2-terraform-e2e
 
-# This GitHub action runs your tests before merging a pull request via merge groups
+# This workflow jobs never run. terraform-e2e-v2.yaml has the terraform e2e workflow which gets executed when PR is added to a merge queue, before merge to main.
+# This workflow is created as a workaround, as mentioned in the discussion linked below. 
 # Merge Group Discussions: https://github.com/orgs/community/discussions/51120
 on:
   pull_request:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 22 * * *'
 
 permissions:
   id-token: write
@@ -20,55 +18,10 @@ jobs:
     if: false #https://github.com/orgs/community/discussions/51120
     name: 🧪 Run Terraform e2e Tests
     runs-on: ubuntu-24.04
-    env:
-      MPF_SUBSCRIPTIONID: ${{ secrets.MPF_SUBSCRIPTIONID }}
-      MPF_TENANTID: ${{ secrets.MPF_TENANTID }}
-      MPF_SPCLIENTID: ${{ secrets.MPF_SPCLIENTID }}
-      MPF_SPCLIENTSECRET: ${{ secrets.MPF_SPCLIENTSECRET }}
-      MPF_SPOBJECTID: ${{ secrets.MPF_SPOBJECTID }}
-    permissions:
-      contents: read
-      pull-requests: write
-      checks: write
-      id-token: write
+
     steps:
       - name: ⤵️ Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - name: 🚧 Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: 🚧 Setup Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
-        with:
-          repo-token: ${{ github.token }}
-
-      - name: 🔀 Download Go dependencies
-        run: task deps:download
-
-      - name: 🔨 Setup Test tools
-        run: task test:tools
-
-      - name: 🚧 Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        with:
-          terraform_wrapper: false
-          terraform_version: "1.10.4"
-        
-      - name: 'Az CLI login - federated'
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_OID_CLIENT_ID }}
-          tenant-id: ${{ secrets.MPF_TENANTID }}
-          subscription-id: ${{ secrets.MPF_SUBSCRIPTIONID }}
-
-      - name: 🧪 Run Terraform E2E Tests
-        run: |
-          export MPF_TFPATH=$(which terraform)
-          echo "Terraform path: $MPF_TFPATH"
-          task teste2e:terraform

--- a/.github/workflows/terraform-e2e-v2.yaml
+++ b/.github/workflows/terraform-e2e-v2.yaml
@@ -1,6 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
-# Terraform Provider testing workflow.
 name: 🧪 v2-terraform-e2e
 
 # This GitHub action runs your tests before merging a pull request via merge groups


### PR DESCRIPTION
- arm-bicep-e2e-PR-v2.yaml and terraform-e2e-PR-v2.yaml are created as workaround as discussed in  https://github.com/orgs/community/discussions/51120. WIth this workaround the arm, bicep and terraform workflows are executed as a part of the merge queue before a PR is merged into main. 