### PR TITLE
Handle / Parse AuthorizationPermissionMismatch Error

### DIFF
--- a/e2eTests/e2eArmInvalid_test.go
+++ b/e2eTests/e2eArmInvalid_test.go
@@ -23,7 +23,6 @@
 package e2etests
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -46,7 +45,7 @@ func TestARMTemplatWhatIfInvalidParams(t *testing.T) {
 	mpfArgs.TemplateFilePath = "../samples/templates/aks.json"
 	mpfArgs.ParametersFilePath = "../samples/templates/aks-invalid-params.json"
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 
@@ -90,7 +89,7 @@ func TestARMTemplatWhatIfInvalidTemplate(t *testing.T) {
 	mpfArgs.TemplateFilePath = "../samples/templates/aks-invalid-template.json"
 	mpfArgs.ParametersFilePath = "../samples/templates/aks-parameters.json"
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 
@@ -134,7 +133,7 @@ func TestARMTemplatWhatIfBlankTemplateAndParams(t *testing.T) {
 	mpfArgs.TemplateFilePath = "../samples/templates/blank-template.json"
 	mpfArgs.ParametersFilePath = "../samples/templates/blank-params.json"
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 

--- a/e2eTests/e2eArm_test.go
+++ b/e2eTests/e2eArm_test.go
@@ -23,7 +23,6 @@
 package e2etests
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -121,7 +120,7 @@ func TestARMTemplatMultiResourceTemplate(t *testing.T) {
 	mpfArgs.TemplateFilePath = "../samples/templates/multi-resource-template.json"
 	mpfArgs.ParametersFilePath = "../samples/templates/multi-resource-parameters.json"
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 
@@ -219,7 +218,7 @@ func TestARMTemplatAksPrivateSubnetTemplate(t *testing.T) {
 	mpfArgs.TemplateFilePath = "../samples/templates/aks-private-subnet.json"
 	mpfArgs.ParametersFilePath = "../samples/templates/aks-private-subnet-parameters.json"
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 

--- a/e2eTests/e2eBicepInvalid_test.go
+++ b/e2eTests/e2eBicepInvalid_test.go
@@ -23,7 +23,6 @@
 package e2etests
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -71,7 +70,7 @@ func TestBicepInvalidParams(t *testing.T) {
 	}
 	// defer os.Remove(armTemplatePath)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 

--- a/e2eTests/e2eBicep_test.go
+++ b/e2eTests/e2eBicep_test.go
@@ -23,7 +23,6 @@
 package e2etests
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -74,7 +73,7 @@ func TestBicepAks(t *testing.T) {
 	}
 	// defer os.Remove(armTemplatePath)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 

--- a/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
+++ b/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
@@ -23,7 +23,6 @@
 package e2etests
 
 import (
-	"context"
 	"os"
 	"path"
 	"runtime"
@@ -60,7 +59,7 @@ func TestTerraformAuthorizationPermissionMismatch(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/authorization-permission-mismatch")
 	log.Infof("wrkDir: %s", wrkDir)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 

--- a/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
+++ b/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
@@ -1,0 +1,87 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package e2etests
+
+import (
+	"context"
+	"os"
+	"path"
+	"runtime"
+	"testing"
+
+	"github.com/Azure/mpf/pkg/infrastructure/authorizationCheckers/terraform"
+	resourceGroupManager "github.com/Azure/mpf/pkg/infrastructure/resourceGroupManager"
+	sproleassignmentmanager "github.com/Azure/mpf/pkg/infrastructure/spRoleAssignmentManager"
+	"github.com/Azure/mpf/pkg/usecase"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+//authorizationFailedErrMsg
+
+func TestTerraformAuthorizationPermissionMismatch(t *testing.T) {
+
+	// import errors can occur for some resources, when identity does not have all required permissions,
+	// as described in https://github.com/hashicorp/terraform-provider-azurerm/issues/27961#issuecomment-2467392936
+	mpfArgs, err := getTestingMPFArgs()
+	if err != nil {
+		t.Skip("required environment variables not set, skipping end to end test")
+	}
+	mpfArgs.MPFMode = "terraform"
+
+	var tfpath string
+	if os.Getenv("MPF_TFPATH") == "" {
+		t.Skip("Terraform Path TF_PATH not set, skipping end to end test")
+	}
+	tfpath = os.Getenv("MPF_TFPATH")
+
+	_, filename, _, _ := runtime.Caller(0)
+	curDir := path.Dir(filename)
+	log.Infof("curDir: %s", curDir)
+	wrkDir := path.Join(curDir, "../samples/terraform/authorization-permission-mismatch")
+	log.Infof("wrkDir: %s", wrkDir)
+	ctx := context.Background()
+
+	mpfConfig := getMPFConfig(mpfArgs)
+
+	var rgManager usecase.ResourceGroupManager
+	var spRoleAssignmentManager usecase.ServicePrincipalRolemAssignmentManager
+	rgManager = resourceGroupManager.NewResourceGroupManager(mpfArgs.SubscriptionID)
+	spRoleAssignmentManager = sproleassignmentmanager.NewSPRoleAssignmentManager(mpfArgs.SubscriptionID)
+
+	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
+	var mpfService *usecase.MPFService
+
+	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, "", true, "")
+	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
+
+	mpfResult, err := mpfService.GetMinimumPermissionsRequired()
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.NotEmpty(t, mpfResult.RequiredPermissions)
+	assert.Equal(t, 11, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+}

--- a/e2eTests/e2eTerraformInvalid_test.go
+++ b/e2eTests/e2eTerraformInvalid_test.go
@@ -23,7 +23,6 @@
 package e2etests
 
 import (
-	"context"
 	"os"
 	"path"
 	"runtime"
@@ -59,7 +58,7 @@ func TestTerraformACIInvalidVarFile(t *testing.T) {
 	varsFile := path.Join(curDir, "../samples/terraform/rg-invalid-tfvars/dev.vars.tfvars")
 	log.Infof("varsFile: %s", varsFile)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 
@@ -101,7 +100,7 @@ func TestTerraformACIInvalidTfFile(t *testing.T) {
 	wrkDir := path.Join(curDir, "../samples/terraform/rg-invalid-tf-file")
 	log.Infof("wrkDir: %s", wrkDir)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 
@@ -139,7 +138,7 @@ func TestTerraformACIInvalidTfExec(t *testing.T) {
 	wrkDir := path.Join(curDir, "../samples/terraform/rg-no-tfvars")
 	log.Infof("wrkDir: %s", wrkDir)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 

--- a/e2eTests/e2eTerraformWithImportAndTargeting_test.go
+++ b/e2eTests/e2eTerraformWithImportAndTargeting_test.go
@@ -23,7 +23,6 @@
 package e2etests
 
 import (
-	"context"
 	"os"
 	"path"
 	"runtime"
@@ -58,7 +57,7 @@ func TestTerraformWithImport(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/existing-resource-import")
 	log.Infof("wrkDir: %s", wrkDir)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 
@@ -105,7 +104,7 @@ func TestTerraformWithTargetting(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/module-test-with-targetting")
 	log.Infof("wrkDir: %s", wrkDir)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 

--- a/e2eTests/e2eTerraform_test.go
+++ b/e2eTests/e2eTerraform_test.go
@@ -23,7 +23,6 @@
 package e2etests
 
 import (
-	"context"
 	"os"
 	"path"
 	"runtime"
@@ -59,7 +58,7 @@ func TestTerraformACI(t *testing.T) {
 	varsFile := path.Join(curDir, "../samples/terraform/aci/dev.vars.tfvars")
 	log.Infof("varsFile: %s", varsFile)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 
@@ -105,7 +104,7 @@ func TestTerraformACINoTfvarsFile(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/rg-no-tfvars")
 	log.Infof("wrkDir: %s", wrkDir)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 
@@ -151,7 +150,7 @@ func TestTerraformModuleTest(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/module-test")
 	log.Infof("wrkDir: %s", wrkDir)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
 
@@ -201,7 +200,7 @@ func TestTerraformModuleTest(t *testing.T) {
 // 	wrkDir := path.Join(curDir, "../samples/terraform/multi-resource")
 // 	varsFile := path.Join(curDir, "../samples/terraform/multi-resource/dev.vars.tfvars")
 
-// 	ctx := context.Background()
+// 	ctx := t.Context()
 
 // 	mpfConfig := presentation.getMPFConfig(mpfArgs)
 

--- a/pkg/domain/authorizationPermissionMismatchErrorParser.go
+++ b/pkg/domain/authorizationPermissionMismatchErrorParser.go
@@ -1,0 +1,79 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+)
+
+type PermissionErrorDetails struct {
+	MissingPermissions string
+	Scope              string
+}
+
+func parseAuthorizationPermissionMismatchError(authorizationFailedErrMsg string) (map[string][]string, error) {
+
+	log.Printf("Attempting to Parse AuthorizationPermissionMismatch Error: @@%s@@", authorizationFailedErrMsg)
+	re := regexp.MustCompile(`retrieving (queue|file|blob) properties for Storage Account \(Subscription: \"([^"]+)\"\nResource Group Name: \"([^"]+)\"\nStorage Account Name: \"([^"]+)\"\): executing request: unexpected status 403 \(403 This request is not authorized to perform this operation using this permission.\) with AuthorizationPermissionMismatch: This request is not authorized to perform this operation using this permission.`)
+
+	matches := re.FindAllStringSubmatch(authorizationFailedErrMsg, -1)
+
+	if len(matches) == 0 {
+		return nil, errors.New("no matches found in 'AuthorizationPermissionMismatch' error message")
+	}
+
+	scopePermissionsMap := make(map[string][]string)
+
+	// Iterate through the matches and populate the map
+	for _, match := range matches {
+		if len(match) == 5 {
+			var action string
+			switch match[1] {
+			case "queue":
+				action = "Microsoft.Storage/storageAccounts/queueServices/read"
+			case "file":
+				action = "Microsoft.Storage/storageAccounts/fileServices/read"
+			case "blob":
+				action = "Microsoft.Storage/storageAccounts/blobServices/read"
+			}
+
+			scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", match[2], match[3], match[4])
+
+			if _, ok := scopePermissionsMap[scope]; !ok {
+				scopePermissionsMap[scope] = make([]string, 0)
+			}
+			scopePermissionsMap[scope] = append(scopePermissionsMap[scope], action)
+		}
+	}
+
+	// if map is empty, return error
+	if len(scopePermissionsMap) == 0 {
+		return nil, errors.New("No scope/permissions found in AuthorizationPermissionMismatch error message")
+	}
+
+	return scopePermissionsMap, nil
+
+}

--- a/pkg/domain/authorizationPermissionMismatchErrorParser_test.go
+++ b/pkg/domain/authorizationPermissionMismatchErrorParser_test.go
@@ -1,0 +1,100 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package domain
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAuthorizationPermissionMismatchError(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    map[string][]string
+		wantErr bool
+	}{
+		{
+			name: "Valid queue error message",
+			input: `retrieving queue properties for Storage Account (Subscription: "SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS"
+Resource Group Name: "rg-nygst"
+Storage Account Name: "sanygst"): executing request: unexpected status 403 (403 This request is not authorized to perform this operation using this permission.) with AuthorizationPermissionMismatch: This request is not authorized to perform this operation using this permission.`,
+			want: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/rg-nygst/providers/Microsoft.Storage/storageAccounts/sanygst": {"Microsoft.Storage/storageAccounts/queueServices/read"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid file error message",
+			input: `retrieving file properties for Storage Account (Subscription: "SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS"
+Resource Group Name: "rg-nygst"
+Storage Account Name: "sanygst"): executing request: unexpected status 403 (403 This request is not authorized to perform this operation using this permission.) with AuthorizationPermissionMismatch: This request is not authorized to perform this operation using this permission.`,
+			want: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/rg-nygst/providers/Microsoft.Storage/storageAccounts/sanygst": {"Microsoft.Storage/storageAccounts/fileServices/read"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid blob error message",
+			input: `retrieving blob properties for Storage Account (Subscription: "SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS"
+Resource Group Name: "rg-nygst"
+Storage Account Name: "sanygst"): executing request: unexpected status 403 (403 This request is not authorized to perform this operation using this permission.) with AuthorizationPermissionMismatch: This request is not authorized to perform this operation using this permission.`,
+			want: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/rg-nygst/providers/Microsoft.Storage/storageAccounts/sanygst": {"Microsoft.Storage/storageAccounts/blobServices/read"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid error message",
+			input:   `some invalid error message`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Empty error message",
+			input:   ``,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid Format Error Message",
+			input: `retrieving blob properties for Storage Account (Subscription: "SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS"
+Resource Group Name: "rg-nygst" WRONG WRONG WRONG
+Storage Account Name: "sanygst"): executing request: unexpected status 403 (403 This request is not authorized to perform this operation using this permission.) with AuthorizationPermissionMismatch: This request is not authorized to perform this operation using this permission.`,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAuthorizationPermissionMismatchError(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseAuthorizationPermissionMismatchError() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseAuthorizationPermissionMismatchError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/usecase/mpfService.go
+++ b/pkg/usecase/mpfService.go
@@ -140,7 +140,7 @@ func (s *MPFService) GetMinimumPermissionsRequired() (domain.MPFResult, error) {
 		log.Debugln("authErrMesg: ", authErrMesg)
 
 		if err == nil && strings.Contains(authErrMesg, RetryDeploymentResponseErrorMessage) {
-			log.Warnf("received retry request from authorization checker ,retrying deployment.... \n", err)
+			log.Warnf("received retry request from authorization checker, retrying deployment.... \n")
 			continue
 		}
 

--- a/samples/terraform/authorization-permission-mismatch/main.tf
+++ b/samples/terraform/authorization-permission-mismatch/main.tf
@@ -1,0 +1,46 @@
+
+
+
+terraform {
+
+}
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = "true"
+  storage_use_azuread        = true
+}
+
+resource "random_id" "rg" {
+  byte_length = 8
+}
+resource "azurerm_resource_group" "rg" {
+  name     = "rg-${random_id.rg.hex}"
+  location = "uksouth"
+}
+
+resource "random_string" "rand" {
+  length  = 8
+  special = false
+  numeric = false
+  upper   = false
+  lower   = true
+}
+
+data "azurerm_client_config" "current" {
+}
+
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+
+resource "azurerm_storage_account" "st" {
+  name                          = "saapermmismatch${random_string.rand.result}"
+  resource_group_name           = azurerm_resource_group.rg.name
+  location                      = azurerm_resource_group.rg.location
+  account_kind                  = "Storage"
+  account_tier                  = "Standard"
+  account_replication_type      = "LRS"
+  public_network_access_enabled = false
+}


### PR DESCRIPTION
Fixes #41 .

- Parse AuthorizationPermissionMismatch to get permission and scope
- Add logic to Retry deployment when "waiting for the Data Plane" message is received along with AuthorizationPermissionMismatch error
- Add unit tests and end to end tests for AuthorizationPermissionMismatch error