### PR TITLE
Append permissions to work around TF provider issue

### DIFF
--- a/docs/known-issues-and-workarounds.MD
+++ b/docs/known-issues-and-workarounds.MD
@@ -1,5 +1,11 @@
 # Known Issues and Workarounds
 
+## Bicep
+
+### Parameter File Format
+
+Currently only ARM type [parameters files](https://github.com/Azure/mpf/blob/main/samples/bicep/aks-private-subnet-invalid-params.json) are supported even for bicep executions. Bicep type parameters files are currently not supported and result in an error. A new feature request has been created to track this issue [issue #12](https://github.com/Azure/mpf/issues/12).
+
 ## Terraform
 
 ### Token Expiry
@@ -12,8 +18,39 @@ The azurerm provider version < 4.2.0 can crash when using resources like `azurer
 
 ### Existing Resource / Import Errors
 
-Creation of certain resources, like the application insights resource, also involves the creation of current billing features resource, as described in the [GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/27961#issuecomment-2467392936). This means that if the identity used by Terraform has permissions to create the application insights resource but not the current billing features resource, the application insights resource will be created in Azure, but the Terraform apply will fail. This means that the creation of the application insights resource will not be tracked by Terraform and the state file will be out of sync with the actual resources in Azure. When the utility adds the required permission and executes Terraform apply again, Terraform will give an error that the resource already exists in Azure and that this can be resolved by importing the resource into the Terraform state file. In this scenario, by default, the MPF utility will import such resources into the Terraform state file and proceed further. It needs to be noted that in the cleanup phase the imported resources will also be deleted.
+Creation of certain resources, like the application insights resource, also involves the creation of current billing features resource, as described in the [GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/27961#issuecomment-2467392936). This means that if the identity used by Terraform has permissions to create the application insights resource but not the current billing features resource, the application insights resource will be created in Azure, but the Terraform apply will fail. This means that the creation of the application insights resource will not be tracked by Terraform and the state file will be out of sync with the actual resources in Azure. When the utility adds the required permission and executes Terraform apply again, Terraform will give an error that the resource already exists in Azure and that this can be resolved by importing the resource into the Terraform state file. As a workaround, the utility automatically appends [missing required permissions](../pkg/domain/appendPermissionsForSpecialCases.go#L12-19) when ```Microsoft.Insights/components/read``` or ```Microsoft.Insights/components/write``` permissions are detected as missing permissions.
+When ```Microsoft.Insights/components/read``` is detected ```Microsoft.Insights/components/currentbillingfeatures/read``` and ```Microsoft.AlertsManagement/smartDetectorAlertRules/read``` permissions are appended. Similarly, when ```Microsoft.Insights/components/write``` is detected ```Microsoft.Insights/components/currentbillingfeatures/write``` and ```Microsoft.AlertsManagement/smartDetectorAlertRules/write``` permissions are appended.
+
 
 ### Billing Features Payload Error
 
 This issue is also related to the [GitHub Issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/27961#issuecomment-2520407658). The utility retries the request to work around this issue.
+
+### Authorization_RequestDenied Error
+
+Currently if you attempt perform actions like adding an Azure AD group via terraform, a Authorization_RequestDenied Error is received.
+
+Sample Error:
+
+```
+Error: Creating group "Group-name-axtwb"
+
+  with ...._ds_group[0],
+  on ....../rbac.tf line 3, in resource "azuread_group" "res_ds_group":
+   3: resource "azuread_group" "res_ds_group" {
+
+GroupsClient.BaseClient.Post(): unexpected status 403 with OData error:
+Authorization_RequestDenied: Insufficient privileges to complete the ...
+```
+
+From the [terraform docs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/guides/service_principal_configuration), adding these permissions may require global admin privilege or admin consent. For this reason the utility cannot automatically add any permissions to the MPF SP to get around this error.
+
+A potential workaround is to disable the Azure AD resource creation which caused this error in the terraform code, and then re-execute the utility.
+
+## Common
+
+### Execution Time Reduction Workarounds
+
+For ARM and Bicep, autoAddReadPermissionForEachWrite is set to true by default. This means that if a write permission is detected, the utility will automatically add the corresponding read permission.
+
+For Terraform autoAddDeletePermissionForEachWrite is set to true by default. This means that if a write permission is detected, the utility will automatically add the corresponding delete permission.

--- a/e2eTests/e2eTerraformWithImportAndTargeting_test.go
+++ b/e2eTests/e2eTerraformWithImportAndTargeting_test.go
@@ -80,7 +80,7 @@ func TestTerraformWithImport(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 13, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 17, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
 }
 
 func TestTerraformWithTargetting(t *testing.T) {

--- a/pkg/domain/appendPermissionsForSpecialCases.go
+++ b/pkg/domain/appendPermissionsForSpecialCases.go
@@ -1,0 +1,32 @@
+package domain
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+var toAppendSpecialCasePermissions = map[string][]string{
+
+	// Below permissions are required for Microsoft.Insights/components due to the following issue:
+	// https://github.com/hashicorp/terraform-provider-azurerm/issues/27961#issuecomment-2467392936
+
+	"Microsoft.Insights/components/read": {
+		"Microsoft.Insights/components/currentbillingfeatures/read",
+		"Microsoft.AlertsManagement/smartDetectorAlertRules/read",
+	},
+	"Microsoft.Insights/components/write": {
+		"Microsoft.Insights/components/currentbillingfeatures/write",
+		"Microsoft.AlertsManagement/smartDetectorAlertRules/write",
+	},
+}
+
+func appendPermissionsForSpecialCases(scpPerms map[string][]string) map[string][]string {
+	for scp, perms := range scpPerms {
+		for _, perm := range perms {
+			if toAppend, ok := toAppendSpecialCasePermissions[perm]; ok {
+				scpPerms[scp] = append(scpPerms[scp], toAppend...)
+				log.Infof("Appended special case permissions for scope %s: %v", scp, toAppend)
+			}
+		}
+	}
+	return scpPerms
+}

--- a/pkg/domain/appendPermissionsForSpecialCases_test.go
+++ b/pkg/domain/appendPermissionsForSpecialCases_test.go
@@ -1,0 +1,117 @@
+package domain
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAppendPermissiosnForSpecialCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string][]string
+		expected map[string][]string
+	}{
+		{
+			name: "No additional permissions appended",
+			input: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44": {"Microsoft.ContainerService/managedClusters/read", "Microsoft.ContainerService/managedClusters/write"},
+			},
+			expected: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44": {"Microsoft.ContainerService/managedClusters/read", "Microsoft.ContainerService/managedClusters/write"},
+			},
+		},
+		{
+			name: "No additional permissions appended for multiple scopes",
+			input: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X47": {"Microsoft.ContainerService/managedClusters/read", "Microsoft.ContainerService/managedClusters/write"},
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X48": {"Microsoft.ContainerService/managedClusters/read", "Microsoft.ContainerService/managedClusters/write"},
+			},
+			expected: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X47": {"Microsoft.ContainerService/managedClusters/read", "Microsoft.ContainerService/managedClusters/write"},
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X48": {"Microsoft.ContainerService/managedClusters/read", "Microsoft.ContainerService/managedClusters/write"},
+			},
+		},
+		{
+			name: "Append for multiple scopes and permissions",
+			input: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X47": {"Microsoft.ContainerService/managedClusters/read", "Microsoft.ContainerService/managedClusters/write", "Microsoft.Insights/components/read"},
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X48": {"Microsoft.ContainerService/managedClusters/read", "Microsoft.ContainerService/managedClusters/write", "Microsoft.Insights/components/write"},
+			},
+			expected: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X47": {
+					"Microsoft.ContainerService/managedClusters/read",
+					"Microsoft.ContainerService/managedClusters/write",
+					"Microsoft.Insights/components/read",
+					"Microsoft.Insights/components/currentbillingfeatures/read",
+					"Microsoft.AlertsManagement/smartDetectorAlertRules/read",
+				},
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X48": {
+					"Microsoft.ContainerService/managedClusters/read",
+					"Microsoft.ContainerService/managedClusters/write",
+					"Microsoft.Insights/components/write",
+					"Microsoft.Insights/components/currentbillingfeatures/write",
+					"Microsoft.AlertsManagement/smartDetectorAlertRules/write",
+				},
+			},
+		},
+		{
+			name: "Additional permissions appended",
+			input: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44": {"Microsoft.Insights/components/read"},
+			},
+			expected: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44": {
+					"Microsoft.Insights/components/read",
+					"Microsoft.Insights/components/currentbillingfeatures/read",
+					"Microsoft.AlertsManagement/smartDetectorAlertRules/read",
+				},
+			},
+		},
+		{
+			name: "Additional permissions appended for write",
+			input: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44": {"Microsoft.Insights/components/write"},
+			},
+			expected: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44": {
+					"Microsoft.Insights/components/write",
+					"Microsoft.Insights/components/currentbillingfeatures/write",
+					"Microsoft.AlertsManagement/smartDetectorAlertRules/write",
+				},
+			},
+		},
+		{
+			name: "Additional permissions appended for multiple scopes",
+			input: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X47": {"Microsoft.Insights/components/read"},
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X48": {"Microsoft.Insights/components/write"},
+			},
+			expected: map[string][]string{
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X47": {
+					"Microsoft.Insights/components/read",
+					"Microsoft.Insights/components/currentbillingfeatures/read",
+					"Microsoft.AlertsManagement/smartDetectorAlertRules/read",
+				},
+				"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X48": {
+					"Microsoft.Insights/components/write",
+					"Microsoft.Insights/components/currentbillingfeatures/write",
+					"Microsoft.AlertsManagement/smartDetectorAlertRules/write",
+				},
+			},
+		},
+		{
+			name:     "Empty input",
+			input:    map[string][]string{},
+			expected: map[string][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := appendPermissionsForSpecialCases(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/domain/authorizationErrorParser.go
+++ b/pkg/domain/authorizationErrorParser.go
@@ -68,7 +68,7 @@ func GetScopePermissionsFromAuthError(authErrMesg string) (map[string][]string, 
 		return nil, fmt.Errorf("Could not parse deployment error for scope/permissions: %s", authErrMesg)
 	}
 
-	return resMap, nil
+	return appendPermissionsForSpecialCases(resMap), nil
 }
 
 // For 'AuthorizationFailed' errors

--- a/pkg/infrastructure/authorizationCheckers/terraform/terraformAuthorizationChecker.go
+++ b/pkg/infrastructure/authorizationCheckers/terraform/terraformAuthorizationChecker.go
@@ -242,7 +242,7 @@ func (a *terraformDeploymentConfig) terraformApply(mpfConfig domain.MPFConfig, t
 		return a.terraformApply(mpfConfig, tf)
 	}
 
-	if strings.Contains(errorMsg, "Authorization") {
+	if strings.Contains(errorMsg, "Authorization") || strings.Contains(errorMsg, "LinkedAccessCheckFailed") {
 		if strings.Contains(errorMsg, WaitingForDataplaneError) {
 			log.Warnln("terraform apply: waiting for dataplane error occured, requesting retry")
 			return RetryDeploymentResponseErrorMessage, nil


### PR DESCRIPTION
Fixes #49 

- This is to workaround the [Terraform azurerm provider, Application Insights resource Issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/27961#issuecomment-2467392936) . As a workaround, the utility automatically appends missing required permissions when ```Microsoft.Insights/components/read``` or ```Microsoft.Insights/components/write``` permissions are detected as missing permissions.
When ```Microsoft.Insights/components/read``` is detected ```Microsoft.Insights/components/currentbillingfeatures/read``` and ```Microsoft.AlertsManagement/smartDetectorAlertRules/read``` permissions are appended. Similarly, when ```Microsoft.Insights/components/write``` is detected ```Microsoft.Insights/components/currentbillingfeatures/write``` and ```Microsoft.AlertsManagement/smartDetectorAlertRules/write``` permissions are appended.
- Implement functionality to append permissions in such special cases (currently aware of only one such case)
- Add Unit Tests
- Modify app insights e2e test to reflect added permissions
- Modify docs