### PR TITLE
Fix MPF CI failure when executed against branch from a fork of the repo

### DIFF
--- a/.github/workflows/mpf-ci.yml
+++ b/.github/workflows/mpf-ci.yml
@@ -182,7 +182,7 @@ jobs:
           overwrite: true
 
       - name: 📢 Publish unit test results
-        if: always()
+        if: github.ref == 'refs/heads/main' || github.event.pull_request.head.repo.full_name == github.repository
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
         with:
           name: 📜 Test results (${{ matrix.cli }} ${{ matrix.version }})


### PR DESCRIPTION
Fixes #54 

- Modified CI workflow so that the publish unit tests result step is not executed when a PR is created from a branch in a fork of the repo.