### PR TITLE
Add feature to support arm and bicep subscription scoped deployments

### DIFF
--- a/.github/workflows/arm-bicep-e2e-v2.yaml
+++ b/.github/workflows/arm-bicep-e2e-v2.yaml
@@ -29,6 +29,7 @@ jobs:
       MPF_SPCLIENTID: ${{ secrets.MPF_SPCLIENTID }}
       MPF_SPCLIENTSECRET: ${{ secrets.MPF_SPCLIENTSECRET }}
       MPF_SPOBJECTID: ${{ secrets.MPF_SPOBJECTID }}
+      MPF_BICEPEXECPATH: "/usr/local/bin/bicep"
     permissions:
       contents: read
       pull-requests: write
@@ -70,7 +71,8 @@ jobs:
           tenant-id: ${{ secrets.MPF_TENANTID }}
           subscription-id: ${{ secrets.MPF_SUBSCRIPTIONID }}
 
-      - name: 🧪 Run ARM and Bicep E2E Tests
-        run: |
-          task teste2e:arm
-          task teste2e:bicep
+      - name: 🧪 Run ARM E2E Tests
+        run: task teste2e:arm
+
+      - name: 🧪 Run Bicep E2E Tests
+        run: task teste2e:bicep

--- a/.github/workflows/arm-bicep-e2e-v2.yaml
+++ b/.github/workflows/arm-bicep-e2e-v2.yaml
@@ -74,5 +74,11 @@ jobs:
       - name: 🧪 Run ARM E2E Tests
         run: task teste2e:arm
 
+      - name: 🧪 Run ARM CLI Tests
+        run: task testcli:arm
+
       - name: 🧪 Run Bicep E2E Tests
         run: task teste2e:bicep
+
+      - name: 🧪 Run Bicep CLI Tests 
+        run: task testcli:bicep

--- a/.github/workflows/arm-bicep-e2e-v2.yaml
+++ b/.github/workflows/arm-bicep-e2e-v2.yaml
@@ -70,5 +70,8 @@ jobs:
           tenant-id: ${{ secrets.MPF_TENANTID }}
           subscription-id: ${{ secrets.MPF_SUBSCRIPTIONID }}
 
-      - name: 🧪 Run ARM Bicep E2E Tests
-        run: task teste2e:armbicep
+      - name: 🧪 Run ARM E2E Tests
+        run: task teste2e:arm
+      
+      - name: 🧪 Run Bicep E2E Tests
+        run: task teste2e:bicep

--- a/.github/workflows/arm-bicep-e2e-v2.yaml
+++ b/.github/workflows/arm-bicep-e2e-v2.yaml
@@ -70,8 +70,7 @@ jobs:
           tenant-id: ${{ secrets.MPF_TENANTID }}
           subscription-id: ${{ secrets.MPF_SUBSCRIPTIONID }}
 
-      - name: 🧪 Run ARM E2E Tests
-        run: task teste2e:arm
-      
-      - name: 🧪 Run Bicep E2E Tests
-        run: task teste2e:bicep
+      - name: 🧪 Run ARM and Bicep E2E Tests
+        run: |
+          task teste2e:arm
+          task teste2e:bicep

--- a/.github/workflows/az-mpf-e2e-arm-bicep.yaml
+++ b/.github/workflows/az-mpf-e2e-arm-bicep.yaml
@@ -25,8 +25,8 @@ name: ARM and Bicep E2E Tests
 on:
   workflow_dispatch:
 
-  schedule:
-    - cron: '0 0 * * *'
+  # schedule:
+  #   - cron: '0 0 * * *'
 
 concurrency:
   group: shared_mpf_service_principal_workflow_group

--- a/.github/workflows/az-mpf-e2e-terraform.yaml
+++ b/.github/workflows/az-mpf-e2e-terraform.yaml
@@ -25,8 +25,8 @@ name: Terraform e2e tests
 on:
   workflow_dispatch:
 
-  schedule:
-    - cron: '0 2 * * *'
+  # schedule:
+  #   - cron: '0 2 * * *'
 
 concurrency:
   group: shared_mpf_service_principal_workflow_group

--- a/.github/workflows/terraform-e2e-v2.yaml
+++ b/.github/workflows/terraform-e2e-v2.yaml
@@ -73,3 +73,9 @@ jobs:
           export MPF_TFPATH=$(which terraform)
           echo "Terraform path: $MPF_TFPATH"
           task teste2e:terraform
+
+      - name: 🧪 Run Terraform CLI Tests
+        run: |
+          export MPF_TFPATH=$(which terraform)
+          echo "Terraform path: $MPF_TFPATH"
+          task testcli:terraform

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ GOTEST = $(GOCMD) test
 GOGET = $(GOCMD) get
 
 # Name of the binary output
-BINARY_NAME = az-mpf
+BINARY_NAME = azmpf
 
 # Main source file
 # MAIN_FILE = main.go

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,13 @@ build-all:
 	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(OUTPUT_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd
 	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $(OUTPUT_DIR)/$(BINARY_NAME)-windows-amd64.exe ./cmd
 
-test-e2e: # arm and bicep tests
+test-e2e-arm: # arm and bicep tests
 	@echo "Running end-to-end tests..."
-	$(GOTEST) ./e2eTests -v -run TestARM TestBicep
+	$(GOTEST) ./e2eTests -v -run TestARM
+
+test-e2e-bicep: # bicep tests
+	@echo "Running end-to-end tests..."
+	$(GOTEST) ./e2eTests -v -run TestBicep
 
 test-e2e-terraform: # terraform tests
 	@echo "Running end-to-end tests..."

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -181,8 +181,44 @@ tasks:
       FORMAT: '{{if eq .GITHUB_ACTIONS "true"}}github-actions{{else}}pkgname-and-test-fails{{end}}'
       LDFLAGS: "-s -w -X main.version=testUnit"
 
+  testcli:arm:
+    desc: Run CLI tests for ARM
+    cmds:
+    - |
+      RESULT_LINE_COUNT=$(go run ./cmd arm --templateFilePath ./samples/templates/aks-private-subnet.json --parametersFilePath ./samples/templates/aks-private-subnet-parameters.json | wc -l)
+      echo "Result line count: $RESULT_LINE_COUNT"
+      if [ "$RESULT_LINE_COUNT" -ne 13 ]; then
+        echo "Expected 13 lines, got $RESULT_LINE_COUNT"
+        exit 1
+      fi
+      echo "Test passed: $RESULT_LINE_COUNT lines"
+
+  testcli:bicep:
+    desc: Run CLI tests for Bicep
+    cmds:
+    - |
+      RESULT_LINE_COUNT=$(go run ./cmd bicep --bicepFilePath ./samples/bicep/aks-private-subnet.bicep --parametersFilePath ./samples/bicep/aks-private-subnet-params.json | wc -l)
+      echo "Result line count: $RESULT_LINE_COUNT"
+      if [ "$RESULT_LINE_COUNT" -ne 13 ]; then
+        echo "Expected 13 lines, got $RESULT_LINE_COUNT"
+        exit 1
+      fi
+      echo "Test passed: $RESULT_LINE_COUNT lines"
+
+  testcli:terraform:
+    desc: Run CLI tests for Bicep
+    cmds:
+    - |
+      RESULT_LINE_COUNT=$(go run ./cmd terraform --workingDir ./samples/terraform/aci --varFilePath ./samples/terraform/aci/dev.vars.tfvars | wc -l)
+      echo "Result line count: $RESULT_LINE_COUNT"
+      if [ "$RESULT_LINE_COUNT" -ne 13 ]; then
+        echo "Expected 13 lines, got $RESULT_LINE_COUNT"
+        exit 1
+      fi
+      echo "Test passed: $RESULT_LINE_COUNT lines"
+
   teste2e:arm:
-    desc: Run e2e tests for ARM and Bicep
+    desc: Run e2e tests for ARM
     cmds:
       - go clean -testcache
       - 'gotestsum --format-hivis --format {{.FORMAT}} --junitfile "testresults.xml" -- ./e2eTests -run TestARM -v -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
@@ -190,9 +226,10 @@ tasks:
     vars:
       FORMAT: '{{if eq .GITHUB_ACTIONS "true"}}github-actions{{else}}pkgname-and-test-fails{{end}}'
       LDFLAGS: "-s -w -X main.version=testAcc"
-  
+
+
   teste2e:bicep:
-    desc: Run e2e tests for ARM and Bicep
+    desc: Run e2e tests for Bicep
     cmds:
       - go clean -testcache
       - 'gotestsum --format-hivis --format {{.FORMAT}} --junitfile "testresults.xml" -- ./e2eTests -run TestBicep -v -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
@@ -200,7 +237,7 @@ tasks:
     vars:
       FORMAT: '{{if eq .GITHUB_ACTIONS "true"}}github-actions{{else}}pkgname-and-test-fails{{end}}'
       LDFLAGS: "-s -w -X main.version=testAcc"
-
+  
   teste2e:terraform:
     desc: Run e2e tests for Terraform
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -206,7 +206,7 @@ tasks:
       echo "Test passed: $RESULT_LINE_COUNT lines"
 
   testcli:terraform:
-    desc: Run CLI tests for Bicep
+    desc: Run CLI tests for Terraform
     cmds:
     - |
       RESULT_LINE_COUNT=$(go run ./cmd terraform --workingDir ./samples/terraform/aci --varFilePath ./samples/terraform/aci/dev.vars.tfvars | wc -l)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -181,11 +181,21 @@ tasks:
       FORMAT: '{{if eq .GITHUB_ACTIONS "true"}}github-actions{{else}}pkgname-and-test-fails{{end}}'
       LDFLAGS: "-s -w -X main.version=testUnit"
 
-  teste2e:armbicep:
+  teste2e:arm:
     desc: Run e2e tests for ARM and Bicep
     cmds:
       - go clean -testcache
-      - 'gotestsum --format-hivis --format {{.FORMAT}} --junitfile "testresults.xml" -- ./e2eTests -run TestARM TestBicep -v -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
+      - 'gotestsum --format-hivis --format {{.FORMAT}} --junitfile "testresults.xml" -- ./e2eTests -run TestARM -v -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
+      # - task: test:getcover
+    vars:
+      FORMAT: '{{if eq .GITHUB_ACTIONS "true"}}github-actions{{else}}pkgname-and-test-fails{{end}}'
+      LDFLAGS: "-s -w -X main.version=testAcc"
+  
+  teste2e:bicep:
+    desc: Run e2e tests for ARM and Bicep
+    cmds:
+      - go clean -testcache
+      - 'gotestsum --format-hivis --format {{.FORMAT}} --junitfile "testresults.xml" -- ./e2eTests -run TestBicep -v -timeout 30m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
       # - task: test:getcover
     vars:
       FORMAT: '{{if eq .GITHUB_ACTIONS "true"}}github-actions{{else}}pkgname-and-test-fails{{end}}'

--- a/cmd/terraformCmd.go
+++ b/cmd/terraformCmd.go
@@ -156,7 +156,7 @@ func getMPFTerraform(cmd *cobra.Command, args []string) {
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(flgWorkingDir, flgTFPath, flgVarFilePath, flgImportExistingResourcesToState, flgTargetModule)
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 
-	displayOptions := getDislayOptions(flgShowDetailedOutput, flgJSONOutput, mpfConfig.ResourceGroup.ResourceGroupResourceID)
+	displayOptions := getDislayOptions(flgShowDetailedOutput, flgJSONOutput, mpfConfig.SubscriptionID)
 
 	mpfResult, err := mpfService.GetMinimumPermissionsRequired()
 	if err != nil {

--- a/docs/commandline-flags-and-env-variables.md
+++ b/docs/commandline-flags-and-env-variables.md
@@ -25,6 +25,7 @@ When used for Terraform, the verbose and debug flags show detailed logs from Ter
 | resourceGroupNamePfx | MPF_RESOURCEGROUPNAMEPFX | Optional           | Prefix for the resource group name. If not provided, default prefix is testdeployrg. For ARM deployments this temporary resource group is created                                |
 | deploymentNamePfx    | MPF_DEPLOYMENTNAMEPFX    | Optional           | Prefix for the deployment name. If not provided, default prefix is testDeploy. For ARM deployments this temporary deployment is created                                |
 | location             | MPF_LOCATION             | Optional           | Location for the resource group. If not provided, default location is eastus                                      |
+| subscriptionScoped     | MPF_SUBSCRIPTIONSCOPED     | Optional           | This flag indicates whether the deployment is scoped to a subscription. If set, the deployment will target a subscription else it is resource group scoped deployment.                                 |
 
 ### Bicep Flags
 
@@ -36,6 +37,7 @@ When used for Terraform, the verbose and debug flags show detailed logs from Ter
 | resourceGroupNamePfx | MPF_RESOURCEGROUPNAMEPFX | Optional           | Prefix for the resource group name. If not provided, default prefix is testdeployrg. For Bicep deployments this temporary resource group is created                                |
 | deploymentNamePfx    | MPF_DEPLOYMENTNAMEPFX    | Optional           | Prefix for the deployment name. If not provided, default prefix is testDeploy. For Bicep deployments this temporary deployment is created                                |
 | location             | MPF_LOCATION             | Optional           | Location for the resource group. If not provided, default location is eastus                                      |
+| subscriptionScoped     | MPF_SUBSCRIPTIONSCOPED     | Optional           | This flag indicates whether the deployment is scoped to a subscription. If set, the deployment will target a subscription else it is resource group scoped deployment.                                 |
 
 ## Terraform Flags
 

--- a/docs/display-options.MD
+++ b/docs/display-options.MD
@@ -16,7 +16,7 @@ export MPF_SPCLIENTID=YOUR_SP_CLIENT_ID
 export MPF_SPCLIENTSECRET=YOUR_SP_CLIENT_SECRET
 export MPF_SPOBJECTID=YOUR_SP_OBJECT_ID
 
-$ ./az-mpf arm --templateFilePath ./samples/templates/aks-private-subnet.json --parametersFilePath ./samples/templates/aks-private-subnet-parameters.json --showDetailedOutput
+$ ./azmpf arm --templateFilePath ./samples/templates/aks-private-subnet.json --parametersFilePath ./samples/templates/aks-private-subnet-parameters.json --showDetailedOutput
 
 ------------------------------------------------------------------------------------------------------------------------------------------
 Permissions Required:
@@ -63,7 +63,7 @@ export MPF_SPCLIENTID=YOUR_SP_CLIENT_ID
 export MPF_SPCLIENTSECRET=YOUR_SP_CLIENT_SECRET
 export MPF_SPOBJECTID=YOUR_SP_OBJECT_ID
 
-$ ./az-mpf arm --templateFilePath ./samples/templates/aks-private-subnet.json --parametersFilePath ./samples/templates/aks-private-subnet-parameters.json --jsonOutput
+$ ./azmpf arm --templateFilePath ./samples/templates/aks-private-subnet.json --parametersFilePath ./samples/templates/aks-private-subnet-parameters.json --jsonOutput
 
 {
   "/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44": [
@@ -103,7 +103,7 @@ export MPF_SPCLIENTID=YOUR_SP_CLIENT_ID
 export MPF_SPCLIENTSECRET=YOUR_SP_CLIENT_SECRET
 export MPF_SPOBJECTID=YOUR_SP_OBJECT_ID
 
-$ ./az-mpf arm --templateFilePath ./samples/templates/aks-private-subnet.json --parametersFilePath ./samples/templates/aks-private-subnet-parameters.json --verbose
+$ ./azmpf arm --templateFilePath ./samples/templates/aks-private-subnet.json --parametersFilePath ./samples/templates/aks-private-subnet-parameters.json --verbose
 
 INFO[0000] Executing MPF for ARM                        
 INFO[0000] TemplateFilePath: ./samples/templates/aks-private-subnet.json 
@@ -167,7 +167,7 @@ export MPF_SPCLIENTID=YOUR_SP_CLIENT_ID
 export MPF_SPCLIENTSECRET=YOUR_SP_CLIENT_SECRET
 export MPF_SPOBJECTID=YOUR_SP_OBJECT_ID
 
-$ ./az-mpf arm --templateFilePath ./samples/templates/multi-resource-template.json --parametersFilePath ./samples/templates/multi-resource-parameters.json --showDetailedOutput 
+$ ./azmpf arm --templateFilePath ./samples/templates/multi-resource-template.json --parametersFilePath ./samples/templates/multi-resource-parameters.json --showDetailedOutput 
 
 ------------------------------------------------------------------------------------------------------------------------------------------
 Permissions Required:
@@ -470,3 +470,27 @@ Microsoft.Compute/virtualMachines/extensions/read
 Microsoft.Compute/virtualMachines/extensions/write
 --------------
 ```
+
+### Subscription scoped Bicep deployment
+
+The --subscriptionScoped flag indicates whether the deployment is scoped to a subscription. If set, the deployment will target a subscription else it is resource group scoped deployment. The following is a sample of subscription scoped Bicep deployment:
+
+```shell
+export MPF_SUBSCRIPTIONID=YOUR_SUBSCRIPTION_ID
+export MPF_TENANTID=YOUR_TENANT_ID
+export MPF_SPCLIENTID=YOUR_SP_CLIENT_ID
+export MPF_SPCLIENTSECRET=YOUR_SP_CLIENT_SECRET
+export MPF_SPOBJECTID=YOUR_SP_OBJECT_ID
+export MPF_BICEPEXECPATH="/opt/homebrew/bin/bicep" # Path to the Bicep executable
+
+$ ./azmpf bicep --bicepFilePath ./samples/bicep/subscription-scope-create-rg.bicep --parametersFilePath ./samples/bicep/subscription-scope-create-rg-params.json  --subscriptionScoped --location eastus2
+------------------------------------------------------------------------------------------------------------------------------------------
+Permissions Required:
+------------------------------------------------------------------------------------------------------------------------------------------
+Microsoft.Resources/deployments/read
+Microsoft.Resources/deployments/write
+Microsoft.Resources/subscriptions/resourceGroups/read
+Microsoft.Resources/subscriptions/resourceGroups/write
+------------------------------------------------------------------------------------------------------------------------------------------
+```
+

--- a/docs/display-options.MD
+++ b/docs/display-options.MD
@@ -471,6 +471,29 @@ Microsoft.Compute/virtualMachines/extensions/write
 --------------
 ```
 
+### Subscription scoped ARM deployment
+
+The --subscriptionScoped flag indicates whether the deployment is scoped to a subscription. If set, the deployment will target a subscription else it is resource group scoped deployment. The following is a sample of subscription scoped ARM deployment:
+
+```shell
+export MPF_SUBSCRIPTIONID=YOUR_SUBSCRIPTION_ID
+export MPF_TENANTID=YOUR_TENANT_ID
+export MPF_SPCLIENTID=YOUR_SP_CLIENT_ID
+export MPF_SPCLIENTSECRET=YOUR_SP_CLIENT_SECRET
+export MPF_SPOBJECTID=YOUR_SP_OBJECT_ID
+export MPF_BICEPEXECPATH="/opt/homebrew/bin/bicep" # Path to the Bicep executable
+
+$ ./azmpf arm --templateFilePath ./samples/templates/subscription-scope-create-rg.json --parametersFilePath ./samples/templates/subscription-scope-create-rg-params.json --subscriptionScoped --location eastus2
+------------------------------------------------------------------------------------------------------------------------------------------
+Permissions Required:
+------------------------------------------------------------------------------------------------------------------------------------------
+Microsoft.Resources/deployments/read
+Microsoft.Resources/deployments/write
+Microsoft.Resources/subscriptions/resourceGroups/read
+Microsoft.Resources/subscriptions/resourceGroups/write
+------------------------------------------------------------------------------------------------------------------------------------------
+```
+
 ### Subscription scoped Bicep deployment
 
 The --subscriptionScoped flag indicates whether the deployment is scoped to a subscription. If set, the deployment will target a subscription else it is resource group scoped deployment. The following is a sample of subscription scoped Bicep deployment:

--- a/docs/installation-and-quickstart.md
+++ b/docs/installation-and-quickstart.md
@@ -8,9 +8,9 @@ For example, to download the latest version for Linux/amd64:
 
 ```shell
 # Please change the version in the URL to the latest version
-curl -LO https://github.com/Azure/mpf/releases/download/v0.13.0/azmpf_0.13.0_linux_amd64.zip
-unzip azmpf_0.13.0_linux_amd64.zip
-mv azmpf_v0.13.0 azmpf
+curl -LO https://github.com/Azure/mpf/releases/download/v0.14.0/azmpf_0.14.0_linux_amd64.zip
+unzip azmpf_0.14.0_linux_amd64.zip
+mv azmpf_v0.14.0 azmpf
 chmod +x ./azmpf
 ```
 
@@ -18,9 +18,9 @@ And for Mac Arm64:
   
 ```shell
 # Please change the version in the URL to the latest version
-curl -LO https://github.com/Azure/mpf/releases/download/v0.13.0/azmpf_0.13.0_darwin_arm64.zip
-unzip azmpf_0.13.0_darwin_arm64.zip
-mv azmpf_v0.13.0 azmpf
+curl -LO https://github.com/Azure/mpf/releases/download/v0.14.0/azmpf_0.14.0_darwin_arm64.zip
+unzip azmpf_0.14.0_darwin_arm64.zip
+mv azmpf_v0.14.0 azmpf
 chmod +x ./azmpf
 ```
 

--- a/e2eTests/e2eArm_test.go
+++ b/e2eTests/e2eArm_test.go
@@ -206,7 +206,7 @@ func TestARMTemplatMultiResourceTemplate(t *testing.T) {
 	// Microsoft.Storage/storageAccounts/read
 	// Microsoft.Storage/storageAccounts/write
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 54, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 54, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }
 
 func TestARMTemplatAksPrivateSubnetTemplate(t *testing.T) {
@@ -258,5 +258,5 @@ func TestARMTemplatAksPrivateSubnetTemplate(t *testing.T) {
 	// Microsoft.Resources/deployments/read
 	// Microsoft.Resources/deployments/write
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }

--- a/e2eTests/e2eBicepSubscriptionScoped_test.go
+++ b/e2eTests/e2eBicepSubscriptionScoped_test.go
@@ -59,8 +59,7 @@ func TestBicepSubscriptionScoped(t *testing.T) {
 		Location:           "eastus2",
 	}
 
-	var spRoleAssignmentManager usecase.ServicePrincipalRolemAssignmentManager
-	spRoleAssignmentManager = spram.NewSPRoleAssignmentManager(mpfArgs.SubscriptionID)
+	spRoleAssignmentManager := spram.NewSPRoleAssignmentManager(mpfArgs.SubscriptionID)
 
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService

--- a/e2eTests/e2eBicepSubscriptionScoped_test.go
+++ b/e2eTests/e2eBicepSubscriptionScoped_test.go
@@ -1,0 +1,85 @@
+package e2etests
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Azure/mpf/pkg/infrastructure/ARMTemplateShared"
+	"github.com/Azure/mpf/pkg/infrastructure/authorizationCheckers/ARMTemplateWhatIf"
+	mpfSharedUtils "github.com/Azure/mpf/pkg/infrastructure/mpfSharedUtils"
+	spram "github.com/Azure/mpf/pkg/infrastructure/spRoleAssignmentManager"
+	"github.com/Azure/mpf/pkg/usecase"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBicepSubscriptionScoped(t *testing.T) {
+
+	mpfArgs, err := getTestingMPFArgs()
+	if err != nil {
+		t.Skip("required environment variables not set, skipping end to end test")
+	}
+
+	if checkBicepTestEnvVars() {
+		t.Skip("required environment variables not set, skipping end to end test")
+	}
+
+	bicepExecPath := os.Getenv("MPF_BICEPEXECPATH")
+	bicepFilePath := "../samples/bicep/subscription-scope-create-rg.bicep"
+	parametersFilePath := "../samples/bicep/subscription-scope-create-rg-params.json"
+
+	bicepFilePath, _ = getAbsolutePath(bicepFilePath)
+	parametersFilePath, _ = getAbsolutePath(parametersFilePath)
+
+	armTemplatePath := strings.TrimSuffix(bicepFilePath, ".bicep") + ".json"
+	bicepCmd := exec.Command(bicepExecPath, "build", bicepFilePath, "--outfile", armTemplatePath)
+	bicepCmd.Dir = filepath.Dir(bicepFilePath)
+
+	_, err = bicepCmd.CombinedOutput()
+	if err != nil {
+		log.Error(err)
+		t.Error(err)
+	}
+	// defer os.Remove(armTemplatePath)
+
+	ctx := t.Context()
+
+	mpfConfig := getMPFConfig(mpfArgs)
+
+	deploymentName := fmt.Sprintf("%s-%s", mpfArgs.DeploymentNamePfx, mpfSharedUtils.GenerateRandomString(7))
+	armConfig := &ARMTemplateShared.ArmTemplateAdditionalConfig{
+		TemplateFilePath:   armTemplatePath,
+		ParametersFilePath: parametersFilePath,
+		DeploymentName:     deploymentName,
+		SubscriptionScoped: true,
+		Location:           "eastus2",
+	}
+
+	var spRoleAssignmentManager usecase.ServicePrincipalRolemAssignmentManager
+	spRoleAssignmentManager = spram.NewSPRoleAssignmentManager(mpfArgs.SubscriptionID)
+
+	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
+	var mpfService *usecase.MPFService
+
+	deploymentAuthorizationCheckerCleaner = ARMTemplateWhatIf.NewARMTemplateWhatIfAuthorizationChecker(mpfArgs.SubscriptionID, *armConfig)
+	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/*", "Microsoft.Resources/subscriptions/operationresults/read"}
+	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	mpfService = usecase.NewMPFService(ctx, nil, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, true, false, false)
+
+	mpfResult, err := mpfService.GetMinimumPermissionsRequired()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check if mpfResult.RequiredPermissions is not empty and has 2 permissions for scope SubscriptionID
+	// Microsoft.Resources/deployments/read
+	// Microsoft.Resources/deployments/write
+	// Microsoft.Resources/subscriptions/resourceGroups/read
+	// Microsoft.Resources/subscriptions/resourceGroups/write
+	assert.NotEmpty(t, mpfResult.RequiredPermissions)
+	assert.Equal(t, 4, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
+}

--- a/e2eTests/e2eBicep_test.go
+++ b/e2eTests/e2eBicep_test.go
@@ -113,7 +113,7 @@ func TestBicepAks(t *testing.T) {
 	// Microsoft.Resources/deployments/read
 	// Microsoft.Resources/deployments/write
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }
 
 func getAbsolutePath(path string) (string, error) {

--- a/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
+++ b/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
@@ -82,5 +82,5 @@ func TestTerraformAuthorizationPermissionMismatch(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 11, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 11, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }

--- a/e2eTests/e2eTerraformWithImportAndTargeting_test.go
+++ b/e2eTests/e2eTerraformWithImportAndTargeting_test.go
@@ -80,7 +80,7 @@ func TestTerraformWithImport(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 17, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 17, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }
 
 func TestTerraformWithTargetting(t *testing.T) {
@@ -127,5 +127,5 @@ func TestTerraformWithTargetting(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }

--- a/e2eTests/e2eTerraform_test.go
+++ b/e2eTests/e2eTerraform_test.go
@@ -82,7 +82,7 @@ func TestTerraformACI(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }
 
 func TestTerraformACINoTfvarsFile(t *testing.T) {
@@ -128,7 +128,7 @@ func TestTerraformACINoTfvarsFile(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 5, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 5, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }
 
 func TestTerraformModuleTest(t *testing.T) {
@@ -174,7 +174,7 @@ func TestTerraformModuleTest(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }
 
 //
@@ -241,5 +241,5 @@ func TestTerraformModuleTest(t *testing.T) {
 // 	// Microsoft.Resources/subscriptions/resourcegroups/write
 // 	//check if mpfResult.RequiredPermissions is not empty and has 54 permissions for scope ResourceGroupResourceID
 // 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-// 	assert.Equal(t, 16, len(mpfResult.RequiredPermissions[mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+// 	assert.Equal(t, 16, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 // }

--- a/pkg/infrastructure/ARMTemplateShared/armTemplateShared.go
+++ b/pkg/infrastructure/ARMTemplateShared/armTemplateShared.go
@@ -1,17 +1,17 @@
 //     MIT License
-// 
+//
 //     Copyright (c) Microsoft Corporation.
-// 
+//
 //     Permission is hereby granted, free of charge, to any person obtaining a copy
 //     of this software and associated documentation files (the "Software"), to deal
 //     in the Software without restriction, including without limitation the rights
 //     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 //     copies of the Software, and to permit persons to whom the Software is
 //     furnished to do so, subject to the following conditions:
-// 
+//
 //     The above copyright notice and this permission notice shall be included in all
 //     copies or substantial portions of the Software.
-// 
+//
 //     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,6 +30,8 @@ type ArmTemplateAdditionalConfig struct {
 	TemplateFilePath   string
 	ParametersFilePath string
 	DeploymentName     string
+	SubscriptionScoped bool
+	Location           string
 }
 
 // Get parameters in standard format that is without the schema, contentVersion and parameters fields

--- a/pkg/presentation/defaultFormatter.go
+++ b/pkg/presentation/defaultFormatter.go
@@ -1,17 +1,17 @@
 //     MIT License
-// 
+//
 //     Copyright (c) Microsoft Corporation.
-// 
+//
 //     Permission is hereby granted, free of charge, to any person obtaining a copy
 //     of this software and associated documentation files (the "Software"), to deal
 //     in the Software without restriction, including without limitation the rights
 //     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 //     copies of the Software, and to permit persons to whom the Software is
 //     furnished to do so, subject to the following conditions:
-// 
+//
 //     The above copyright notice and this permission notice shall be included in all
 //     copies or substantial portions of the Software.
-// 
+//
 //     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,13 +26,21 @@ import (
 	"fmt"
 	"io"
 	"sort"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func (d *displayConfig) displayText(w io.Writer) error {
 
 	sm := d.result.RequiredPermissions
+	if len(sm) == 0 {
+		fmt.Println("No permissions required")
+		return nil
+	}
 
-	defaultPerms := sm[d.displayOptions.DefaultResourceGroupResourceID]
+	log.Debugf("All permissions required: %v", sm)
+
+	defaultPerms := sm[d.displayOptions.SubscriptionID]
 
 	// sort permissions
 	// defaultPerms = getUniqueSlice(defaultPerms)
@@ -58,7 +66,7 @@ func (d *displayConfig) displayText(w io.Writer) error {
 
 	// print permissions for other scopes
 	for scope, perms := range sm {
-		if scope == d.displayOptions.DefaultResourceGroupResourceID {
+		if scope == d.displayOptions.SubscriptionID {
 			continue
 		}
 

--- a/pkg/presentation/resultPresenter.go
+++ b/pkg/presentation/resultPresenter.go
@@ -29,9 +29,9 @@ import (
 )
 
 type DisplayOptions struct {
-	ShowDetailedOutput             bool
-	JSONOutput                     bool
-	DefaultResourceGroupResourceID string
+	ShowDetailedOutput bool
+	JSONOutput         bool
+	SubscriptionID     string
 }
 
 // type ResultDisplayer interface {

--- a/pkg/usecase/mpfService.go
+++ b/pkg/usecase/mpfService.go
@@ -123,14 +123,14 @@ func (s *MPFService) GetMinimumPermissionsRequired() (domain.MPFResult, error) {
 
 	// Add initial permissions to requiredPermissions map
 	log.Infoln("Adding initial permissions to requiredPermissions map")
-	s.requiredPermissions[s.mpfConfig.ResourceGroup.ResourceGroupResourceID] = append(s.requiredPermissions[s.mpfConfig.ResourceGroup.ResourceGroupResourceID], s.permissionsToAddToResult...)
+	s.requiredPermissions[s.mpfConfig.SubscriptionID] = append(s.requiredPermissions[s.mpfConfig.SubscriptionID], s.permissionsToAddToResult...)
 
 	maxIterations := 50
 	iterCount := 0
 	for {
 		authErrMesg, err := s.deploymentAuthCheckerCleaner.GetDeploymentAuthorizationErrors(s.mpfConfig)
 
-		log.Debugf("Iteration Number: %d \n", iterCount)
+		log.Infof("Iteration Number: %d \n", iterCount)
 
 		if authErrMesg == "" && err == nil {
 			log.Infoln("Authorization Successful")
@@ -177,14 +177,14 @@ func (s *MPFService) GetMinimumPermissionsRequired() (domain.MPFResult, error) {
 		log.Infoln("Adding mising scopes/permissions to final result map...")
 		for k, v := range scpMp {
 			s.requiredPermissions[k] = append(s.requiredPermissions[k], v...)
-			s.requiredPermissions[s.mpfConfig.ResourceGroup.ResourceGroupResourceID] = append(s.requiredPermissions[s.mpfConfig.ResourceGroup.ResourceGroupResourceID], v...)
+			s.requiredPermissions[s.mpfConfig.SubscriptionID] = append(s.requiredPermissions[s.mpfConfig.SubscriptionID], v...)
 		}
 
 		// assign permission to role
 		log.Infoln("Adding permission/scope to role...........")
-		log.Debugln("Number of Permissions added to role:", len(s.requiredPermissions[s.mpfConfig.ResourceGroup.ResourceGroupResourceID]))
+		log.Debugln("Number of Permissions added to role:", len(s.requiredPermissions[s.mpfConfig.SubscriptionID]))
 
-		permissionsIncludingInitialPermissions := append(s.initialPermissionsToAdd, s.requiredPermissions[s.mpfConfig.ResourceGroup.ResourceGroupResourceID]...)
+		permissionsIncludingInitialPermissions := append(s.initialPermissionsToAdd, s.requiredPermissions[s.mpfConfig.SubscriptionID]...)
 		err = s.spRoleAssignmentManager.CreateUpdateCustomRole(s.mpfConfig.SubscriptionID, s.mpfConfig.Role, permissionsIncludingInitialPermissions)
 
 		// err = s.spRoleAssignmentManager.CreateUpdateCustomRole(s.mpfConfig.SubscriptionID, s.mpfConfig.ResourceGroup.ResourceGroupName, s.mpfConfig.Role, s.requiredPermissions[s.mpfConfig.ResourceGroup.ResourceGroupResourceID])

--- a/samples/bicep/subscription-scope-create-rg-params.json
+++ b/samples/bicep/subscription-scope-create-rg-params.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        }
+}               

--- a/samples/bicep/subscription-scope-create-rg.bicep
+++ b/samples/bicep/subscription-scope-create-rg.bicep
@@ -1,0 +1,16 @@
+targetScope = 'subscription'
+
+@description('Generates a stable unique string for the resource group name')
+var randomString = uniqueString(subscription().id, 'resourceGroupNameSeed')
+
+@description('Resource group name')
+var resourceGroupName = 'rg-${take(randomString, 13)}'
+
+@description('location of the resource group')
+var location = 'eastus2'
+
+// Module to deploy the resource group at the subscription scope
+resource coreResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+    name: resourceGroupName
+    location: location
+  }

--- a/samples/templates/subscription-scope-create-rg-params.json
+++ b/samples/templates/subscription-scope-create-rg-params.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        }
+}               

--- a/samples/templates/subscription-scope-create-rg.json
+++ b/samples/templates/subscription-scope-create-rg.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+
+    "variables": {
+      "randomString": "[uniqueString(subscription().id, 'resourceGroupNameSeed')]",
+      "resourceGroupName": "[format('rg-{0}', take(variables('randomString'), 13))]",
+      "location": "eastus2"
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Resources/resourceGroups",
+        "apiVersion": "2021-04-01",
+        "name": "[variables('resourceGroupName')]",
+        "location": "[variables('location')]"
+      }
+    ]
+  }


### PR DESCRIPTION
- Add feature to support arm and bicep subscription scoped deployments fixes #76 
- Add sample and e2e test for subscription scoped deployments
- Add CLI tests for arm, bicep, terraform
- Add sample for subscription scoped bicep deployment in display options
- Update command line flags to include required flags for subscription scoped deployments
