### PR TITLE
Fix orphaned resource group in test subscription, due to e2e test issue

### DIFF
--- a/samples/terraform/module-test-with-targetting/main.tf
+++ b/samples/terraform/module-test-with-targetting/main.tf
@@ -1,30 +1,19 @@
 
 
 
-resource "random_id" "rg" {
-  byte_length = 8
-}
 
-resource "azurerm_resource_group" "this" {
-  location = "East US2" # Location used just for the example
-  name     = "rg-${random_id.rg.hex}"
-}
 
 
 
 module "law" {
   source                       = "./modules/law"
-  location                     = azurerm_resource_group.this.location
   log_analytics_workspace_name = var.log_analytics_workspace_name
-  resource_group_name          = azurerm_resource_group.this.name
   tags                         = var.tags
 }
 
 module "law2" {
   source                       = "./modules/law"
-  location                     = azurerm_resource_group.this.location
   log_analytics_workspace_name = "${var.log_analytics_workspace_name}2"
-  resource_group_name          = azurerm_resource_group.this.name
   tags                         = var.tags
 }
 

--- a/samples/terraform/module-test-with-targetting/modules/law/law.tf
+++ b/samples/terraform/module-test-with-targetting/modules/law/law.tf
@@ -5,7 +5,7 @@ module "log_analytics_workspace" {
   version = "0.4.1"
 
   name                = var.log_analytics_workspace_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
   tags                = var.tags
 }

--- a/samples/terraform/module-test-with-targetting/modules/law/rg.tf
+++ b/samples/terraform/module-test-with-targetting/modules/law/rg.tf
@@ -1,0 +1,8 @@
+resource "random_id" "rg" {
+  byte_length = 8
+}
+
+resource "azurerm_resource_group" "this" {
+  location = "East US2" # Location used just for the example
+  name     = "rg-${random_id.rg.hex}"
+}

--- a/samples/terraform/module-test-with-targetting/modules/law/variables.tf
+++ b/samples/terraform/module-test-with-targetting/modules/law/variables.tf
@@ -1,17 +1,4 @@
 
-
-variable "location" {
-  type        = string
-  description = "The location/region where the resources will be deployed."
-  nullable    = false
-}
-
-# This is required for most resource modules
-variable "resource_group_name" {
-  type        = string
-  description = "The resource group where the resources will be deployed."
-}
-
 variable "tags" {
   type        = map(string)
   default     = null


### PR DESCRIPTION
Fix orphaned resource group in test subscription, due to terraform module targetting e2e test issue.

To fix this resource group resource is also moved into the module. This ensures it is removed by the terraform destroy -target.