### PR TITLE
remove windows tests from merge group

### DIFF
--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -4,11 +4,9 @@
 
 name: 🧪 windows-e2e-tests
 
-# This GitHub action runs your tests before merging a pull request
-# via merge groups
+# This GitHub action runs your tests on workflow dispatch and scheduled runs
 # Merge Group Discussions: https://github.com/orgs/community/discussions/51120
 "on":
-  merge_group:
   workflow_dispatch:
   schedule:
     - cron: '0 19 * * *'


### PR DESCRIPTION
remove windows tests from merge group as already the e2e tests take around an hour, with windows e2e tests total duration is more than 90 mins. Instead windows e2e tests are executed nightly