### PR TITLE
fix(ci-test): workflow does not contain permissions

### DIFF
--- a/.github/workflows/az-mpf-ci.yaml
+++ b/.github/workflows/az-mpf-ci.yaml
@@ -21,10 +21,11 @@
 #     SOFTWARE
 
 name: Build and Unit Test az-mpf
-permissions:
-  contents: read
 
 on: [push]
+
+permissions:
+  contents: read
 
 jobs:
   build-test:


### PR DESCRIPTION
Fix for [https://github.com/Azure/mpf/security/code-scanning/3](https://github.com/Azure/mpf/security/code-scanning/3)

This pull request makes a small update to the GitHub Actions workflow configuration by explicitly setting the workflow permissions.

- Explicitly adds `permissions: contents: read` to the `.github/workflows/az-mpf-ci.yaml` workflow file, which clarifies the workflow's access level to repository contents.
