### PR TITLE
fix: improve role detachment logic in DetachRolesFromSP method

### DIFF
--- a/pkg/infrastructure/spRoleAssignmentManager/defaultSPRoleAssignmentManager.go
+++ b/pkg/infrastructure/spRoleAssignmentManager/defaultSPRoleAssignmentManager.go
@@ -304,11 +304,25 @@ func (r *SPRoleAssignmentManager) DetachRolesFromSP(ctx context.Context, subscri
 		}
 
 		for _, roleAssignment := range page.Value {
-			if roleAssignment.Properties != nil && roleAssignment.Properties.RoleDefinitionID != nil && strings.EqualFold(*roleAssignment.Properties.RoleDefinitionID, role.RoleDefinitionResourceID) {
-				_, err := r.azAPIClient.RoleAssignmentsDeletionClient.DeleteByID(ctx, string(*roleAssignment.ID), nil)
-				if err != nil {
-					return err
+			if roleAssignment.ID == nil {
+				continue
+			}
+
+			// Backward-compatible behavior: if role.RoleDefinitionResourceID is empty,
+			// detach *all* role assignments for the SP.
+			if role.RoleDefinitionResourceID != "" {
+				if roleAssignment.Properties == nil || roleAssignment.Properties.RoleDefinitionID == nil {
+					continue
 				}
+
+				if !strings.EqualFold(*roleAssignment.Properties.RoleDefinitionID, role.RoleDefinitionResourceID) {
+					continue
+				}
+			}
+
+			_, err := r.azAPIClient.RoleAssignmentsDeletionClient.DeleteByID(ctx, string(*roleAssignment.ID), nil)
+			if err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
This pull request updates the logic for detaching roles from a Service Principal (SP) to improve backward compatibility and robustness. The main change ensures that, if no specific role definition is provided, all role assignments for the SP are detached; otherwise, only the matching role assignment is removed. It also adds checks to avoid processing assignments with missing IDs.

Role detachment logic improvements:

* Updated `DetachRolesFromSP` in `defaultSPRoleAssignmentManager.go` to:
  - Detach all role assignments if `RoleDefinitionResourceID` is empty (backward-compatible behavior).
  - Skip role assignments with a missing `ID` or missing `RoleDefinitionID` when appropriate.
  - Only detach assignments that match the provided `RoleDefinitionResourceID` when it is specified.