### PR TITLE
fix: update E2E and lint workflows to handle cancelled job results

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name != 'pull_request'
     name: 🧪 E2E Tests
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -123,8 +123,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: ✅ OK
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 0
       - name: 🛑 Failure
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -112,8 +112,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: ✅ OK
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 0
       - name: 🛑 Failure
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configurations to improve the handling of cancelled jobs and increase the timeout for end-to-end (E2E) tests. The main changes ensure that cancelled jobs are treated consistently as failures and that E2E tests have more time to complete.