### PR TITLE
Resolve intermittent nightly e2e test failures

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -41,6 +41,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: 🧹 Clean Terraform sample artifacts
+        if: matrix.type == 'terraform'
+        run: git clean -ffdx samples/terraform
       - name: 🚧 Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -226,7 +226,7 @@ tasks:
       MPF_BICEPEXECPATH: "{{.MPF_BICEPEXECPATH}}"
     cmds:
       - go clean -testcache
-      - gotestsum --format-hivis --format {{.FORMAT}} -- ./e2eTests -v -timeout 60m -run {{.TEST_RUN}}
+      - gotestsum --format-hivis --format {{.FORMAT}} -- ./e2eTests -v -timeout 60m -p 1 -parallel 1 -run {{.TEST_RUN}}
 
   testunit:
     desc: Run unit tests

--- a/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
+++ b/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
@@ -58,6 +58,11 @@ func TestTerraformAuthorizationPermissionMismatch(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/authorization-permission-mismatch")
 	log.Infof("wrkDir: %s", wrkDir)
+
+	// Clean up Terraform artifacts before and after test
+	cleanTerraformWorkingDir(t, wrkDir)
+	t.Cleanup(func() { cleanTerraformWorkingDir(t, wrkDir) })
+
 	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)

--- a/e2eTests/e2eTerraformInvalid_test.go
+++ b/e2eTests/e2eTerraformInvalid_test.go
@@ -54,6 +54,11 @@ func TestTerraformACIInvalidVarFile(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/rg-invalid-tfvars")
 	log.Infof("wrkDir: %s", wrkDir)
+
+	// Clean up Terraform artifacts before and after test
+	cleanTerraformWorkingDir(t, wrkDir)
+	t.Cleanup(func() { cleanTerraformWorkingDir(t, wrkDir) })
+
 	varsFile := path.Join(wrkDir, "dev.vars.tfvars")
 	log.Infof("varsFile: %s", varsFile)
 
@@ -98,6 +103,10 @@ func TestTerraformACIInvalidTfFile(t *testing.T) {
 	wrkDir := path.Join(curDir, "../samples/terraform/rg-invalid-tf-file")
 	log.Infof("wrkDir: %s", wrkDir)
 
+	// Clean up Terraform artifacts before and after test
+	cleanTerraformWorkingDir(t, wrkDir)
+	t.Cleanup(func() { cleanTerraformWorkingDir(t, wrkDir) })
+
 	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
@@ -134,6 +143,10 @@ func TestTerraformACIInvalidTfExec(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/rg-no-tfvars")
 	log.Infof("wrkDir: %s", wrkDir)
+
+	// Clean up Terraform artifacts before and after test
+	cleanTerraformWorkingDir(t, wrkDir)
+	t.Cleanup(func() { cleanTerraformWorkingDir(t, wrkDir) })
 
 	ctx := t.Context()
 

--- a/e2eTests/e2eTerraformWithImportAndTargeting_test.go
+++ b/e2eTests/e2eTerraformWithImportAndTargeting_test.go
@@ -56,6 +56,11 @@ func TestTerraformWithImport(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/existing-resource-import")
 	log.Infof("wrkDir: %s", wrkDir)
+
+	// Clean up Terraform artifacts before and after test
+	cleanTerraformWorkingDir(t, wrkDir)
+	t.Cleanup(func() { cleanTerraformWorkingDir(t, wrkDir) })
+
 	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)
@@ -102,6 +107,11 @@ func TestTerraformWithTargetting(t *testing.T) {
 	log.Infof("curDir: %s", curDir)
 	wrkDir := path.Join(curDir, "../samples/terraform/module-test-with-targetting")
 	log.Infof("wrkDir: %s", wrkDir)
+
+	// Clean up Terraform artifacts before and after test
+	cleanTerraformWorkingDir(t, wrkDir)
+	t.Cleanup(func() { cleanTerraformWorkingDir(t, wrkDir) })
+
 	ctx := t.Context()
 
 	mpfConfig := getMPFConfig(mpfArgs)

--- a/pkg/infrastructure/spRoleAssignmentManager/defaultSPRoleAssignmentManager.go
+++ b/pkg/infrastructure/spRoleAssignmentManager/defaultSPRoleAssignmentManager.go
@@ -322,6 +322,12 @@ func (r *SPRoleAssignmentManager) DetachRolesFromSP(ctx context.Context, subscri
 
 			_, err := r.azAPIClient.RoleAssignmentsDeletionClient.DeleteByID(ctx, string(*roleAssignment.ID), nil)
 			if err != nil {
+				// If the SP does not have permission to delete the role assignment
+				// (403 AuthorizationFailed), log a warning and continue with best-effort cleanup.
+				if strings.Contains(err.Error(), "AuthorizationFailed") || strings.Contains(err.Error(), "403") {
+					log.Warnf("Unable to delete role assignment %s (continuing): %v", *roleAssignment.ID, err)
+					continue
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
Resolve intermittent nightly e2e test failures. These started after moving to new matrix execution.

Fixes #201 

- Add cleanTerraformWorkingDir helper to clean .terraform/, terraform.tfstate, .terraform.lock.hcl, and tfplan files before and after each test
- Add -p 1 -parallel 1 flag to force sequential test execution within package
- Add git clean step in CI workflow to clean Terraform sample artifacts
- Handle 403 errors gracefully in role assignment deletion with warning log