### PR TITLE
feat: add --initialPermissions flag to reduce execution time

### DIFF
--- a/cmd/armCmd.go
+++ b/cmd/armCmd.go
@@ -146,6 +146,9 @@ func getMPFARM(cmd *cobra.Command, args []string) {
 	initialPermissionsToAdd = []string{"Microsoft.Resources/deployments/*", "Microsoft.Resources/subscriptions/operationresults/read"}
 	permissionsToAddToResult = []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
 
+	// Add initial permissions from flag if provided (supports comma-separated string or @file.json)
+	initialPermissionsToAdd, permissionsToAddToResult = appendUserInitialPermissions(initialPermissionsToAdd, permissionsToAddToResult)
+
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, true, false, true)
 
 	log.Infof("Show Detailed Output: %t\n", flgShowDetailedOutput)

--- a/cmd/bicepCmd.go
+++ b/cmd/bicepCmd.go
@@ -171,6 +171,9 @@ func getMPFBicep(cmd *cobra.Command, args []string) {
 	initialPermissionsToAdd = []string{"Microsoft.Resources/deployments/*", "Microsoft.Resources/subscriptions/operationresults/read"}
 	permissionsToAddToResult = []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
 
+	// Add initial permissions from flag if provided (supports comma-separated string or @file.json)
+	initialPermissionsToAdd, permissionsToAddToResult = appendUserInitialPermissions(initialPermissionsToAdd, permissionsToAddToResult)
+
 	// Always auto-create resource group since only resource group scoped deployments are supported
 	var autoCreateResourceGroup = true
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, true, false, autoCreateResourceGroup)

--- a/cmd/rootCmd_test.go
+++ b/cmd/rootCmd_test.go
@@ -1,0 +1,143 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseInitialPermissions(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		want        []string
+		wantErr     bool
+		setupFile   bool
+		fileContent string
+	}{
+		{
+			name:    "empty string returns nil",
+			input:   "",
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "single permission",
+			input:   "Microsoft.Storage/storageAccounts/read",
+			want:    []string{"Microsoft.Storage/storageAccounts/read"},
+			wantErr: false,
+		},
+		{
+			name:  "comma-separated permissions",
+			input: "Microsoft.Storage/storageAccounts/read,Microsoft.Storage/storageAccounts/write",
+			want: []string{
+				"Microsoft.Storage/storageAccounts/read",
+				"Microsoft.Storage/storageAccounts/write",
+			},
+			wantErr: false,
+		},
+		{
+			name:  "comma-separated permissions with spaces",
+			input: "Microsoft.Storage/storageAccounts/read, Microsoft.Storage/storageAccounts/write , Microsoft.Storage/storageAccounts/listKeys/action",
+			want: []string{
+				"Microsoft.Storage/storageAccounts/read",
+				"Microsoft.Storage/storageAccounts/write",
+				"Microsoft.Storage/storageAccounts/listKeys/action",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "file reference with valid JSON",
+			input:     "@testperms.json",
+			setupFile: true,
+			fileContent: `{
+				"RequiredPermissions": {
+					"": [
+						"Microsoft.Storage/storageAccounts/read",
+						"Microsoft.Storage/storageAccounts/write"
+					]
+				}
+			}`,
+			want: []string{
+				"Microsoft.Storage/storageAccounts/read",
+				"Microsoft.Storage/storageAccounts/write",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "file reference to non-existent file",
+			input:   "@nonexistent.json",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:        "file reference with invalid JSON",
+			input:       "@invalid.json",
+			setupFile:   true,
+			fileContent: `not valid json`,
+			want:        nil,
+			wantErr:     true,
+		},
+		{
+			name:      "file reference with empty permissions array",
+			input:     "@empty.json",
+			setupFile: true,
+			fileContent: `{
+				"RequiredPermissions": {
+					"": []
+				}
+			}`,
+			want:    []string{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup file if needed
+			if tt.setupFile {
+				filename := tt.input[1:] // Remove @ prefix
+				tmpDir := t.TempDir()
+				filePath := filepath.Join(tmpDir, filename)
+				err := os.WriteFile(filePath, []byte(tt.fileContent), 0644)
+				if err != nil {
+					t.Fatalf("failed to create test file: %v", err)
+				}
+				// Update input to use absolute path
+				tt.input = "@" + filePath
+			}
+
+			got, err := parseInitialPermissions(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseInitialPermissions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseInitialPermissions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/terraformCmd.go
+++ b/cmd/terraformCmd.go
@@ -139,6 +139,9 @@ func getMPFTerraform(cmd *cobra.Command, args []string) {
 	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
 	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
 
+	// Add initial permissions from flag if provided (supports comma-separated string or @file.json)
+	initialPermissionsToAdd, permissionsToAddToResult = appendUserInitialPermissions(initialPermissionsToAdd, permissionsToAddToResult)
+
 	// Check if permissions file from previous failed run exists
 	if terraform.DoesTFFileExist(flgWorkingDir, FoundPermissionsFromFailedRunFilename) {
 		prevResult, err := terraform.LoadMPFResultFromFile(flgWorkingDir, FoundPermissionsFromFailedRunFilename)

--- a/docs/known-issues-and-workarounds.MD
+++ b/docs/known-issues-and-workarounds.MD
@@ -8,6 +8,32 @@ Currently only ARM type [parameters files](https://github.com/Azure/mpf/blob/mai
 
 ## Terraform
 
+### Remote Backend Access Denied
+
+When using a remote backend (e.g., Azure Storage for Terraform state), MPF removes all existing role assignments from the service principal before starting analysis. This can cause Terraform to fail with a 403 error when trying to access the backend.
+
+**Workaround**: Use the `--initialPermissions` flag to specify the permissions required to access the remote backend. These permissions will be added to the custom role before Terraform runs.
+
+Example for Azure Storage backend:
+
+```bash
+azmpf terraform \
+  --initialPermissions "Microsoft.Storage/storageAccounts/read,Microsoft.Storage/storageAccounts/listKeys/action,Microsoft.Storage/storageAccounts/blobServices/containers/read,Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read,Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write" \
+  --tfPath $(which terraform) \
+  --workingDir ./my-terraform \
+  # ... other required flags
+```
+
+Or create a JSON file with the permissions and reference it:
+
+```bash
+azmpf terraform \
+  --initialPermissions @backend-permissions.json \
+  # ... other flags
+```
+
+See [Initial Permissions](./commandline-flags-and-env-variables.md#initial-permissions) for more details on the JSON file format.
+
 ### Token Expiry
 
 If your default Azure credentials token issued for the utility expires before the utility completes the execution, that execution will fail. When this happens, the utility saves the permissions inferred up to that point in the Terraform module directory, and these are automatically added next time the utility executes for the same Terraform module directory.

--- a/pkg/domain/mpfConfig.go
+++ b/pkg/domain/mpfConfig.go
@@ -52,10 +52,20 @@ type MPFConfig struct {
 type MPFResult struct {
 	// The map from which the minimum permissions will be calculated
 	RequiredPermissions map[string][]string
+	// IterationCount is the number of iterations MPF took to discover all permissions.
+	// A value of 0 means all required permissions were provided upfront via initialPermissions.
+	IterationCount int
 }
 
 func GetMPFResult(requiredPermissions map[string][]string) MPFResult {
 	return MPFResult{
 		RequiredPermissions: getMapWithUniqueValues(requiredPermissions),
+	}
+}
+
+func GetMPFResultWithIterationCount(requiredPermissions map[string][]string, iterationCount int) MPFResult {
+	return MPFResult{
+		RequiredPermissions: getMapWithUniqueValues(requiredPermissions),
+		IterationCount:      iterationCount,
 	}
 }

--- a/pkg/infrastructure/authorizationCheckers/terraform/fileManager_test.go
+++ b/pkg/infrastructure/authorizationCheckers/terraform/fileManager_test.go
@@ -49,7 +49,7 @@ func TestSaveResultAsJSON(t *testing.T) {
 				},
 			},
 			wantErr:    false,
-			wantOutput: `{"RequiredPermissions":{"":["Microsoft.Authorization/roleAssignments/delete","Microsoft.Authorization/roleAssignments/read","Microsoft.Authorization/roleAssignments/write"]}}`,
+			wantOutput: `{"RequiredPermissions":{"":["Microsoft.Authorization/roleAssignments/delete","Microsoft.Authorization/roleAssignments/read","Microsoft.Authorization/roleAssignments/write"]},"IterationCount":0}`,
 		},
 		{
 			name: "valid MPFResult with detailed permissions",
@@ -80,7 +80,7 @@ func TestSaveResultAsJSON(t *testing.T) {
 				},
 			},
 			wantErr:    false,
-			wantOutput: `{"RequiredPermissions":{"":["Microsoft.ContainerService/managedClusters/read","Microsoft.ContainerService/managedClusters/write","Microsoft.Network/virtualNetworks/read","Microsoft.Network/virtualNetworks/subnets/read","Microsoft.Network/virtualNetworks/subnets/write","Microsoft.Network/virtualNetworks/write","Microsoft.Resources/deployments/read","Microsoft.Resources/deployments/write"],"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44/providers/Microsoft.ContainerService/managedClusters/azmpfakstestcluster":["Microsoft.ContainerService/managedClusters/read","Microsoft.ContainerService/managedClusters/write"],"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44/providers/Microsoft.Network/virtualNetworks/azmpfakstestvnet":["Microsoft.Network/virtualNetworks/read","Microsoft.Network/virtualNetworks/write"],"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44/providers/Microsoft.Network/virtualNetworks/azmpfakstestvnet/subnets/azmpfakstestsubnet":["Microsoft.Network/virtualNetworks/subnets/read","Microsoft.Network/virtualNetworks/subnets/write"]}}`,
+			wantOutput: `{"RequiredPermissions":{"":["Microsoft.ContainerService/managedClusters/read","Microsoft.ContainerService/managedClusters/write","Microsoft.Network/virtualNetworks/read","Microsoft.Network/virtualNetworks/subnets/read","Microsoft.Network/virtualNetworks/subnets/write","Microsoft.Network/virtualNetworks/write","Microsoft.Resources/deployments/read","Microsoft.Resources/deployments/write"],"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44/providers/Microsoft.ContainerService/managedClusters/azmpfakstestcluster":["Microsoft.ContainerService/managedClusters/read","Microsoft.ContainerService/managedClusters/write"],"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44/providers/Microsoft.Network/virtualNetworks/azmpfakstestvnet":["Microsoft.Network/virtualNetworks/read","Microsoft.Network/virtualNetworks/write"],"/subscriptions/SSSSSSSS-SSSS-SSSS-SSSS-SSSSSSSSSSSS/resourceGroups/testdeployrg-1Gb2X44/providers/Microsoft.Network/virtualNetworks/azmpfakstestvnet/subnets/azmpfakstestsubnet":["Microsoft.Network/virtualNetworks/subnets/read","Microsoft.Network/virtualNetworks/subnets/write"]},"IterationCount":0}`,
 		},
 		{
 			name: "empty MPFResult",
@@ -88,7 +88,7 @@ func TestSaveResultAsJSON(t *testing.T) {
 				RequiredPermissions: map[string][]string{},
 			},
 			wantErr:    false,
-			wantOutput: `{"RequiredPermissions":{}}`,
+			wantOutput: `{"RequiredPermissions":{},"IterationCount":0}`,
 		},
 	}
 


### PR DESCRIPTION
## Summary

This PR implements the `--initialPermissions` flag (closes #91) which allows users to specify permissions upfront to reduce MPF execution time. This also provides a workaround for the Terraform remote backend issue (#172).

## Changes

### New Feature: `--initialPermissions` flag
- Added as a **global flag** available to all commands (arm, bicep, terraform)
- Supports two formats:
  - **Comma-separated list**: `--initialPermissions "perm1,perm2,perm3"`
  - **JSON file reference**: `--initialPermissions @path/to/file.json`

### Implementation
- `parseInitialPermissions()` - Parses comma-separated or @file.json format
- `appendUserInitialPermissions()` - Helper to reduce code duplication across commands
- `IterationCount` field added to `MPFResult` to track discovery iterations

### Testing
- Added `TestParseInitialPermissions` unit tests for parsing logic
- Added `TestTerraformACIWithInitialPermissions` e2e test that verifies 0 iterations when all permissions are provided upfront

### Documentation
- Updated [commandline-flags-and-env-variables.md](docs/commandline-flags-and-env-variables.md) with usage examples
- Added "Remote Backend Access Denied" section to [known-issues-and-workarounds.MD](docs/known-issues-and-workarounds.MD)

## Use Cases

1. **Reduce execution time** - Seed known permissions to skip discovery iterations
2. **Terraform remote backend** - Provide storage account permissions before MPF runs
3. **CI/CD pipelines** - Use cached permission files from previous runs

## Example Usage

```bash
# Comma-separated
azmpf terraform --initialPermissions "Microsoft.Storage/storageAccounts/read,Microsoft.Storage/storageAccounts/listKeys/action" ...

# From file
azmpf terraform --initialPermissions @backend-permissions.json ...
```

## Related Issues
- Closes #91
- Provides workaround for #172
