### PR TITLE
docs: add release process skills file

### DIFF
--- a/skills/release-process.md
+++ b/skills/release-process.md
@@ -81,14 +81,14 @@ This mirrors the CI lint workflow (`.github/workflows/lint.yml`) and helps avoid
 
 ## Key Files Involved
 
-| File | Purpose |
-|------|---------|
-| `.goreleaser.yml` | GoReleaser build/release configuration (targets, archives, signing, changelog) |
-| `.github/workflows/release.yml` | GitHub Actions workflow triggered on tag push |
-| `.github/workflows/lint.yml` | Lint workflow that validates YAML, Go, and markdown |
-| `Taskfile.yml` | Task runner config — use `task lint` to run all linters locally |
-| `docs/installation-and-quickstart.md` | User-facing installation docs with version-specific download URLs |
-| `go.mod` | Go version and module dependencies |
+| File                                  | Purpose                                                                        |
+|---------------------------------------|--------------------------------------------------------------------------------|
+| `.goreleaser.yml`                     | GoReleaser build/release configuration (targets, archives, signing, changelog) |
+| `.github/workflows/release.yml`       | GitHub Actions workflow triggered on tag push                                  |
+| `.github/workflows/lint.yml`          | Lint workflow that validates YAML, Go, and markdown                            |
+| `Taskfile.yml`                        | Task runner config — use `task lint` to run all linters locally                |
+| `docs/installation-and-quickstart.md` | User-facing installation docs with version-specific download URLs              |
+| `go.mod`                              | Go version and module dependencies                                             |
 
 ## Important Considerations for Release Authors
 


### PR DESCRIPTION
## Summary

Adds a skills file () documenting the key steps, commands, and considerations for creating a new release of Azure/mpf.

## What's Included

- Step-by-step release process (8 steps)
- Commands for analyzing changes, updating docs, linting, tagging, and validating
- Key files involved in the release process
- Important considerations for release authors (Go version compatibility, goreleaser naming, local linting with `task lint`, YAML formatting, Azure deployment validation)

Closes #220