### PR TITLE
build: adopt standard CLI release conventions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,22 +12,33 @@ before:
     - go mod download
 
 archives:
-  - files:
-      - src: LICENSE
-        dst: LICENSE.txt
+  - id: azmpf
+    ids:
+      - azmpf
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     formats:
-      - zip
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - none*
 
 builds:
-  - dir: cmd
+  - id: azmpf
+    binary: "{{ .ProjectName }}"
+    dir: cmd
     env:
       - CGO_ENABLED=0
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .Date }}
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .Date }}
     goos:
       - windows
       - linux
@@ -42,15 +53,19 @@ builds:
         goarch: "386"
       - goos: windows
         goarch: arm
-    binary: "{{ .ProjectName }}_v{{ .Version }}"
+        goarm: "6"
 
 sboms:
-  - id: default
-    disable: false
+  - id: archive
+    artifacts: archive
+  - id: source
+    artifacts: source
+  - id: binary
+    artifacts: binary
 
 checksum:
   algorithm: sha256
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  name_template: "{{ .ProjectName }}_SHA256SUMS.txt"
 
 signs:
   - artifacts: checksum

--- a/docs/installation-and-quickstart.md
+++ b/docs/installation-and-quickstart.md
@@ -8,9 +8,8 @@ For example, to download the latest version for Linux/amd64:
 
 ```shell
 # Please change the version in the URL to the latest version
-curl -LO https://github.com/Azure/mpf/releases/download/v0.16.0/azmpf_0.16.0_linux_amd64.zip
-unzip azmpf_0.16.0_linux_amd64.zip
-mv azmpf_v0.16.0 azmpf
+curl -LO https://github.com/Azure/mpf/releases/download/v0.17.0/azmpf_linux_amd64.tar.gz
+tar -xzf azmpf_linux_amd64.tar.gz
 chmod +x ./azmpf
 ```
 
@@ -18,9 +17,8 @@ For Mac Arm64:
 
 ```shell
 # Please change the version in the URL to the latest version
-curl -LO https://github.com/Azure/mpf/releases/download/v0.16.0/azmpf_0.16.0_darwin_arm64.zip
-unzip azmpf_0.16.0_darwin_arm64.zip
-mv azmpf_v0.16.0 azmpf
+curl -LO https://github.com/Azure/mpf/releases/download/v0.17.0/azmpf_darwin_arm64.tar.gz
+tar -xzf azmpf_darwin_arm64.tar.gz
 chmod +x ./azmpf
 ```
 
@@ -28,9 +26,8 @@ And for Windows:
 
 ```powershell
 # Please change the version in the URL to the latest version
-Invoke-WebRequest -Uri "https://github.com/Azure/mpf/releases/download/v0.16.0/azmpf_0.16.0_windows_amd64.zip" -OutFile "azmpf_0.16.0_windows_amd64.zip"
-Expand-Archive -Path "azmpf_0.16.0_windows_amd64.zip" -DestinationPath "."
-Rename-Item -Path "azmpf_v0.16.0.exe" -NewName "azmpf.exe"
+Invoke-WebRequest -Uri "https://github.com/Azure/mpf/releases/download/v0.17.0/azmpf_windows_amd64.zip" -OutFile "azmpf_windows_amd64.zip"
+Expand-Archive -Path "azmpf_windows_amd64.zip" -DestinationPath "."
 ```
 
 ## Creating a service principal for MPF


### PR DESCRIPTION
## Summary

Adopts standard CLI release conventions, incorporating the changes from #222.

### Changes to `.goreleaser.yml`
- **`tar.gz`** for Linux/macOS, **`zip`** for Windows only (via `format_overrides`)
- **Plain binary name** (`azmpf`) — no version suffix, no extra `mv` step for users
- **Archive names** without version (`azmpf_linux_amd64.tar.gz`) — version is already in the release tag URL
- **Expanded SBOM** coverage: archive, source, and binary
- **Cleaner ldflags** formatting (multi-line)
- Added explicit build/archive IDs and `goarm` specification

### Changes to `docs/installation-and-quickstart.md`
- Linux/macOS: `tar -xzf` instead of `unzip`, no `mv` step needed
- Windows: no `Rename-Item` step needed
- Updated version to v0.17.0

### Changes to `skills/release-process.md`
- Updated naming conventions guidance to match new format
- Updated validation commands

Includes changes from #222 (which can be closed after this is merged).

Closes #223