### PR TITLE
fix: update AKS Kubernetes version from 1.32 to 1.35 in e2e test templates

### DIFF
--- a/e2eTests/e2eArm_test.go
+++ b/e2eTests/e2eArm_test.go
@@ -467,7 +467,7 @@ func TestARMTemplatAksPrivateSubnetTemplateFullDeployment(t *testing.T) {
 		t.Error(err)
 	}
 
-	//check if mpfResult.RequiredPermissions is not empty and has 8 permissions for scope ResourceGroupResourceID
+	//check if mpfResult.RequiredPermissions is not empty and has 9 permissions for scope ResourceGroupResourceID
 	// Microsoft.ContainerService/managedClusters/read
 	// Microsoft.ContainerService/managedClusters/write
 	// Microsoft.Network/virtualNetworks/read

--- a/samples/bicep/aks-private-subnet.bicep
+++ b/samples/bicep/aks-private-subnet.bicep
@@ -34,7 +34,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2023-05-01' = {
     type: 'SystemAssigned'
   }
   properties: {
-    kubernetesVersion: '1.32'
+    kubernetesVersion: '1.35'
     dnsPrefix: clusterName
     servicePrincipalProfile: {}
     agentPoolProfiles: [

--- a/samples/templates/aks-private-subnet.json
+++ b/samples/templates/aks-private-subnet.json
@@ -72,7 +72,7 @@
         "type": "SystemAssigned"
       },
       "properties": {
-        "kubernetesVersion": "1.32",
+        "kubernetesVersion": "1.35",
         "dnsPrefix": "[parameters('clusterName')]",
         "agentPoolProfiles": [
           {


### PR DESCRIPTION
## Summary

Fixes #260

Updates the hardcoded Kubernetes version in AKS sample templates from `1.32` to `1.35` (latest GA, supported until March 2027).

## Problem

Kubernetes 1.32 was moved to LTS-only around April 15, 2026. ARM preflight validation now rejects AKS deployments with `K8sVersionNotSupported` (HTTP 400) **before** evaluating subnet-level permissions. This causes MPF to discover only 8 permissions instead of 9, breaking two e2e tests that have been failing on every nightly since April 15.

## Changes

| File | Change |
|------|--------|
| `samples/templates/aks-private-subnet.json` | `kubernetesVersion: 1.32` → `1.35` |
| `samples/bicep/aks-private-subnet.bicep` | `kubernetesVersion: 1.32` → `1.35` |
| `e2eTests/e2eArm_test.go` | Fixed comment (said 8, should be 9) |

## Verification

- **ARM e2e test** (`TestARMTemplatAksPrivateSubnetTemplateFullDeployment`): ✅ PASSED locally with both 1.33 and 1.35 — 3 iterations, 9 permissions discovered, deployment succeeded.
- **Bicep e2e test**: Could not run locally (bicep binary incompatible with local arch), but the template change is identical. CI will validate.