### PR TITLE
ci: update golangci-lint installer SHA to fix Lint (go) checks

### DIFF
--- a/.taskfiles/golang.Taskfile.yml
+++ b/.taskfiles/golang.Taskfile.yml
@@ -19,7 +19,7 @@ vars:
       goreleaser: latest
   GO_INSTALLER_SHA:
     map:
-      golangciLint: 870ddc133592c3609f26af3b6f05ce2dd4a7afda # 2025-10-13 golangci/golangci-lint install.sh
+      golangciLint: 35b2189782a6a059489289257e6523550167cb64 # 2026-05-01 golangci/golangci-lint install.sh
 
 tasks:
   # * Install GoReleaser


### PR DESCRIPTION
## Summary

Updates the pinned `install.sh` SHA for golangci-lint from `870ddc1` (2025-10-13) to `35b2189` (2026-05-01) in `.taskfiles/golang.Taskfile.yml`.

## Problem

Since May 1, 2026, the upstream [golangci/golangci-lint install.sh was updated](https://github.com/golangci/golangci-lint/commit/35b2189782a6a059489289257e6523550167cb64) with new binary checksums for v2.12.1. Because `GO_VERSION.golangciLint` is set to `latest`, CI downloads v2.12.1 binaries but the old pinned `install.sh` does not contain matching checksums, causing:

```
hash_sha256_verify checksum for golangci-lint-2.12.1-linux-amd64.tar.gz did not verify
```

This breaks `🧹 Lint (go)` and `🧹 Check Lint` on all PRs and merge groups.

## Changes

- `.taskfiles/golang.Taskfile.yml`: Update `GO_INSTALLER_SHA.golangciLint` to `35b2189782a6a059489289257e6523550167cb64`

Fixes #265