### PR TITLE
ci: update Go to 1.26.3 to fix govulncheck failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/mpf
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1


### PR DESCRIPTION
## Summary

Updates Go toolchain from 1.26.2 to 1.26.3 to resolve `govulncheck` failures in CI.

## Problem

The `go:lint` task fails because `govulncheck` detects 2 known vulnerabilities in the Go 1.26.2 standard library:

- **GO-2026-4971**: Panic in `net.Dialer.DialContext` on Windows
- **GO-2026-4918**: Infinite loop in HTTP/2 transport with bad SETTINGS_MAX_FRAME_SIZE

Both are fixed in Go 1.26.3.

## Changes

- Updated `go.mod` directive from `go 1.26.2` to `go 1.26.3`

Fixes #268