### PR TITLE
ci: pin Taskfile tool versions on Linux and Windows (phase 1 of #277)

### DIFF
--- a/.taskfiles/azure.Taskfile.yml
+++ b/.taskfiles/azure.Taskfile.yml
@@ -6,9 +6,9 @@ version: "3"
 vars:
   AZURE_VERSION:
     map:
-      az: latest
-      azd: latest
-      bicep: latest
+      az: 2.86.0
+      azd: 1.25.2
+      bicep: 0.43.8
   AZURE_INSTALLER_SHA:
     map:
       azd: 0340065907dee7ca71cd68ed132033cabb38cbce # 2025-03-27 Azure/azure-dev cli/installer/install-azd.sh

--- a/.taskfiles/github.Taskfile.yml
+++ b/.taskfiles/github.Taskfile.yml
@@ -7,10 +7,10 @@ vars:
   GITHUB_VERSION:
     map:
       actionlint: latest
-      act: latest
-      pinact: latest
-      ghalint: latest
-      gh: latest
+      act: 0.2.88
+      pinact: 4.0.0
+      ghalint: 1.5.6
+      gh: 2.92.0
   GITHUB_INSTALLER_SHA:
     map:
       actionlint: 62c50a97a146fe36a8951a2a365158c4a4795ba8 # v1.7.11 rhysd/actionlint scripts/download-actionlint.bash

--- a/.taskfiles/golang.Taskfile.yml
+++ b/.taskfiles/golang.Taskfile.yml
@@ -6,17 +6,17 @@ version: "3"
 vars:
   GO_VERSION:
     map:
-      dlv: latest
-      gopls: latest
-      deadcode: latest
-      golangciLint: latest
-      gotestsum: latest
-      govulncheck: latest
-      goimports: latest
-      gofumpt: latest
-      goTestCoverage: latest
-      gocoverCobertura: latest
-      goreleaser: latest
+      dlv: v1.26.3
+      gopls: v0.22.0
+      deadcode: v0.45.0
+      golangciLint: 2.12.2
+      gotestsum: v1.13.0
+      govulncheck: v1.3.0
+      goimports: v0.45.0
+      gofumpt: v0.10.0
+      goTestCoverage: v2.18.8
+      gocoverCobertura: v1.5.0
+      goreleaser: 2.16.0
   GO_INSTALLER_SHA:
     map:
       golangciLint: 35b2189782a6a059489289257e6523550167cb64 # 2026-05-01 golangci/golangci-lint install.sh

--- a/.taskfiles/javascript.Taskfile.yml
+++ b/.taskfiles/javascript.Taskfile.yml
@@ -6,7 +6,7 @@ version: "3"
 vars:
   JAVASCRIPT_VERSION:
     map:
-      prettier: latest
+      prettier: 3.8.3
 
 tasks:
   # * Install Prettier

--- a/.taskfiles/markdown.Taskfile.yml
+++ b/.taskfiles/markdown.Taskfile.yml
@@ -7,7 +7,7 @@ vars:
   MARKDOWN_VERSION:
     map:
       markdownlintCli2: latest
-      markdownTableFormatter: latest
+      markdownTableFormatter: 1.7.0
 
 tasks:
   # * Install markdownlint-cli2

--- a/.taskfiles/runtime.Taskfile.yml
+++ b/.taskfiles/runtime.Taskfile.yml
@@ -6,10 +6,10 @@ version: "3"
 vars:
   RUNTIME_VERSION:
     map:
-      uv: latest
-      fnm: latest
+      uv: 0.11.16
+      fnm: 1.39.0
       pwsh: latest
-      golang: latest
+      golang: 1.26.3
   RUNTIME_INSTALLER_SHA:
     map:
       fnm: bfb186034978b1ddaf87501eb1633bdc42a5c0a6 # 2026-03-09 Schniz/fnm .ci/install.sh

--- a/.taskfiles/scripts/install_terraform.sh
+++ b/.taskfiles/scripts/install_terraform.sh
@@ -84,8 +84,13 @@ log "Installing ${TOOL_NAME}"
 if [[ "${VERSION}" == "latest" ]]; then
   apt-get install -y terraform || die "Failed to install ${TOOL_NAME}"
 else
-  # Try to install specific version (format: terraform=version)
-  apt-get install -y "terraform=${VERSION}" || die "Failed to install ${TOOL_NAME} version ${VERSION}"
+  # HashiCorp apt packages sometimes carry a Debian revision suffix
+  # (e.g. terraform=1.15.4-1). Try the bare version first, then fall
+  # back to the -1 suffix so a pinned semver like 1.15.4 resolves
+  # regardless of which form the apt repo currently publishes.
+  apt-get install -y "terraform=${VERSION}" \
+    || apt-get install -y "terraform=${VERSION}-1" \
+    || die "Failed to install ${TOOL_NAME} version ${VERSION} (tried ${VERSION} and ${VERSION}-1)"
 fi
 
 log "✓ Successfully installed ${TOOL_NAME}"

--- a/.taskfiles/shell.Taskfile.yml
+++ b/.taskfiles/shell.Taskfile.yml
@@ -6,8 +6,8 @@ version: "3"
 vars:
   SHELL_VERSION:
     map:
-      shellcheck: latest
-      shfmt: latest
+      shellcheck: 0.11.0
+      shfmt: 3.13.1
 
 tasks:
   # * Install shellcheck

--- a/.taskfiles/terraform.Taskfile.yml
+++ b/.taskfiles/terraform.Taskfile.yml
@@ -6,8 +6,8 @@ version: "3"
 vars:
   TERRAFORM_VERSION:
     map:
-      terraform: latest
-      opentofu: latest
+      terraform: 1.15.4
+      opentofu: 1.12.1
   TERRAFORM_INSTALLER_SHA:
     map:
       opentofu: c4f7de951e69f7c11b04e2e97b72b1e4e447e5bc # 2024-12-26 opentofu/get.opentofu.org static/install-opentofu.sh

--- a/.taskfiles/yaml.Taskfile.yml
+++ b/.taskfiles/yaml.Taskfile.yml
@@ -6,7 +6,7 @@ version: "3"
 vars:
   YAML_VERSION:
     map:
-      yamllint: latest
+      yamllint: 1.38.0
 
 tasks:
   # * Install YAMLlint


### PR DESCRIPTION
## Summary

Pins tool versions in 9 `.taskfiles/*.Taskfile.yml` files away from `latest`, addressing **phase 1 of #277** (supply-chain hardening on Linux and Windows install paths).

This is a deliberately narrow re-scope of [#281](https://github.com/Azure/mpf/pull/281) (closed unmerged with 18 reviewer comments). Only the `*_VERSION: map:` scalar values change, plus one small, narrowly-scoped fix to `install_terraform.sh` so the Terraform pin actually resolves against the HashiCorp apt repo (see below).

## What changed

27 of 30 tools pinned to concrete semver across 9 maps. Values match those proposed in [#281](https://github.com/Azure/mpf/pull/281). Three tools intentionally left at `latest` and tracked as follow-ups (see below).

| Map (file) | Pinned tools |
|---|---|
| `GO_VERSION` (`golang.Taskfile.yml`) | `dlv`, `gopls`, `deadcode`, `golangciLint`, `gotestsum`, `govulncheck`, `goimports`, `gofumpt`, `goTestCoverage`, `gocoverCobertura`, `goreleaser` |
| `AZURE_VERSION` (`azure.Taskfile.yml`) | `az`, `azd`, `bicep` |
| `GITHUB_VERSION` (`github.Taskfile.yml`) | `act`, `pinact`, `ghalint`, `gh` |
| `JAVASCRIPT_VERSION` (`javascript.Taskfile.yml`) | `prettier` |
| `MARKDOWN_VERSION` (`markdown.Taskfile.yml`) | `markdownTableFormatter` |
| `RUNTIME_VERSION` (`runtime.Taskfile.yml`) | `uv`, `fnm`, `golang` |
| `SHELL_VERSION` (`shell.Taskfile.yml`) | `shellcheck`, `shfmt` |
| `TERRAFORM_VERSION` (`terraform.Taskfile.yml`) | `terraform`, `opentofu` |
| `YAML_VERSION` (`yaml.Taskfile.yml`) | `yamllint` |

### One script change: `install_terraform.sh`

HashiCorp's apt repo sometimes publishes Terraform with a bare version (`terraform=1.15.4`) and sometimes with a Debian revision suffix (`terraform=1.15.4-1`). The script now tries the bare form first and falls back to `<version>-1` on failure, so a single pinned semver in the Taskfile resolves either way.

This is the only installer-script change in this PR. Terraform is a high-value supply-chain target, so the small script tweak was preferred over either leaving Terraform unpinned or pushing apt-packaging knowledge into the YAML.

## Why this PR is small

[#281](https://github.com/Azure/mpf/pull/281) bundled value pinning, installer-script normalization, `_internal.Taskfile.yml` v-prefix handling, and a full `setup_pwsh.sh` rewrite into one PR. Eighteen unaddressed reviewer comments later it was closed. This PR keeps only the value-pinning portion (plus the one Terraform-script fix above) so each remaining concern can be reviewed on its own merits in a focused follow-up.

## Coverage after merge

- **CI pipelines:** every install task invoked by `.github/workflows/` (`task runtime:setup:uv`, `task go:tools:test`, `task az:install:bicep`, `task tf:install:terraform`, `task go:install:govulncheck`, `task go:install:goreleaser`, etc.) resolves to a fixed version, except `actionlint` and `markdownlint-cli2` (see deferred list).
- **Linux and Windows dev machines:** pinned for the 27 covered tools.
- **macOS via devcontainer:** pinned (devcontainer is Linux-based, so it goes through the pinned Linux scripts).
- **Native macOS (no devcontainer):** still goes through `_install:brew`, which maps formulas like `bicep@0.43.8` that Homebrew does not publish. Native-macOS setup is expected to fail until phase 2 of #277. The devcontainer is the supported macOS workflow today.

## Deliberately left at `latest` (each tracked as a follow-up)

| Tool | Reason |
|---|---|
| `pwsh` | `setup_pwsh.sh` `die`s on any non-`latest` value. Pinning requires the script rewrite (FU-3). CI uses runner-preinstalled `pwsh`, so this only affects dev machines. |
| `actionlint` | `install_actionlint.sh` prepends `v` to numeric inputs, but upstream `download-actionlint.bash` requires bare `X.Y.Z`. Wrapper bug must be fixed first (FU-2). |
| `markdownlint-cli2` | `internal:command:version` precondition (`grep -F` against `markdownlint-cli2 --help`) doesn't match at the pinned value — needs version-check normalization first (FU-1). |

## Other deferred follow-ups

None introduce a new silent supply-chain regression in CI — they are either dev-machine-only, loud failures rather than silent `latest` fallback, or pre-existing behavior unchanged by this commit.

- **FU-1** — `_internal.Taskfile.yml` version normalization (strip `v`, try both forms)
- **FU-2** — installer-script `v`-prefix stripping in `install_actionlint.sh`, `install_gh.sh`, `install_opentofu.sh`
- **FU-3** — `setup_pwsh.sh` direct-download rewrite with SHA256 verification
- **FU-4** — Phase 2 of #277: native-macOS supply-chain hardening (replace `_install:brew` with tagged-release downloaders)
- **FU-6** — `_install:winget` `ignore_error: true`: pre-existing soft-fail policy. A rejected `winget --version X` on `windows-2025` could fall through to a pre-installed tool. Should be tightened in its own focused follow-up.
- **FU-7** — Renovate automation (`renovate.json` + inline `# renovate:` comments)
- **FU-8** — Top-of-map docblock pinning convention
- **FU-9** — Devcontainer feature pinning (`.devcontainer/devcontainer.json`)

## What reviewers should focus on

1. Are the 27 pinned values themselves correct (typos, mismatched `v` prefix)?
2. Is the `install_terraform.sh` try-then-fallback acceptable, or should `terraform=<ver>-1` be the canonical form / split into a separate Taskfile var?
3. Is the "phase 1 / phase 2" split acceptable, or should #277 not be referenced until macOS is also pinned?
4. Are the three `latest` exceptions adequately justified in the deferred table?

This PR intentionally does **not** address: any other installer script, `_internal.Taskfile.yml`, `setup_pwsh.sh`, devcontainer, Renovate, or docblocks. Comments about those are welcome but will be acted on in the linked follow-ups, not here.

Refs #277.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
