### PR TITLE
ci: pin actionlint and markdownlint-cli2 versions in Taskfiles

### DIFF
--- a/.taskfiles/_internal.Taskfile.yml
+++ b/.taskfiles/_internal.Taskfile.yml
@@ -42,13 +42,13 @@ tasks:
     cmds:
       - cmd: |
           {{if ne .VER "latest"}}
-            {{.CMD}} | grep -F "{{.VER}}"
+            { {{.CMD}} 2>&1 || true; } | grep -F "{{.VER}}"
           {{end}}
         platforms: [linux, darwin]
       - cmd: |
           {{if ne .VER "latest"}}
             {{.PWSH}} '
-              $match = (& {{.CMD}}) | Select-String -Pattern "{{.VER}}" -SimpleMatch
+              $match = (& {{.CMD}} 2>&1) | Select-String -Pattern "{{.VER}}" -SimpleMatch
               if (-not $match) { exit 1 }
             '
           {{end}}

--- a/.taskfiles/github.Taskfile.yml
+++ b/.taskfiles/github.Taskfile.yml
@@ -6,7 +6,7 @@ version: "3"
 vars:
   GITHUB_VERSION:
     map:
-      actionlint: latest
+      actionlint: 1.7.12
       act: 0.2.88
       pinact: 4.0.0
       ghalint: 1.5.6

--- a/.taskfiles/markdown.Taskfile.yml
+++ b/.taskfiles/markdown.Taskfile.yml
@@ -6,7 +6,7 @@ version: "3"
 vars:
   MARKDOWN_VERSION:
     map:
-      markdownlintCli2: latest
+      markdownlintCli2: 0.23.0
       markdownTableFormatter: 1.7.0
 
 tasks:

--- a/.taskfiles/runtime.Taskfile.yml
+++ b/.taskfiles/runtime.Taskfile.yml
@@ -8,6 +8,8 @@ vars:
     map:
       uv: 0.11.16
       fnm: 1.39.0
+      # pwsh stays "latest": its installers use the Microsoft package repo /
+      # Homebrew, which only provide the latest release and reject version pins.
       pwsh: latest
       golang: 1.26.5
   RUNTIME_INSTALLER_SHA:

--- a/.taskfiles/scripts/install_actionlint.sh
+++ b/.taskfiles/scripts/install_actionlint.sh
@@ -69,11 +69,13 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-# Normalize VERSION: empty/whitespace -> "latest", numeric -> add "v" prefix
+# Normalize VERSION: empty/whitespace -> "latest". The pinned
+# download-actionlint.bash expects a bare semantic version (e.g. 1.7.12) or
+# "latest", so strip any leading "v" prefix from a specific version.
 if [[ -z "${VERSION//[[:space:]]/}" ]]; then
   VERSION="latest"
-elif [[ "${VERSION}" != "latest" && "${VERSION}" =~ ^[0-9] ]]; then
-  VERSION="v${VERSION}"
+elif [[ "${VERSION}" != "latest" ]]; then
+  VERSION="${VERSION#v}"
 fi
 
 # Determine install directory


### PR DESCRIPTION
Pins the remaining `latest` tool versions in the Taskfiles to specific releases, addressing the supply-chain and reproducibility concerns in the issue. The `GO_VERSION` map in `golang.Taskfile.yml` was already fully pinned; this change covers the other unpinned entries found during the audit.

Changes:

- `github.Taskfile.yml`: `actionlint` pinned to `1.7.12` (current latest).
- `markdown.Taskfile.yml`: `markdownlintCli2` pinned to `0.23.0` (current latest).

Pinning surfaced two latent bugs in the install/verify tooling that only manifested once a specific version was actually requested (previously masked by `latest`). Both are fixed here:

- `install_actionlint.sh` prepended a `v` to numeric versions and passed `v1.7.12` to the pinned `download-actionlint.bash`, which only accepts a bare `1.7.12` or `latest` and rejected it. The installer now strips any leading `v` instead of adding one.
- The shared `command:version` check ran `<tool> --help | grep ...` under `bash -o pipefail`. `markdownlint-cli2 --help` exits non-zero, so the pipeline failed even when the version matched. The check now neutralizes the wrapped command's exit code (and also inspects stderr) while still requiring the version string to be present.

Intentionally left unpinned:

- `runtime.Taskfile.yml`: `pwsh` stays `latest`. Its installers use the Microsoft package repository (Linux) and Homebrew (macOS), which only provide the latest release; `setup_pwsh.sh` explicitly errors out for any non-`latest` value. A comment now documents this so the entry isn't mistaken for an oversight.

The `latest` occurrences remaining in `_internal.Taskfile.yml` are template conditionals (comparisons against the string `"latest"`), not version pins. The installer scripts under `.taskfiles/scripts/` default to `latest` only when no version is passed — the Taskfiles always pass an explicit pinned version.

Fixes #277
