### PR TITLE
test(terraform): pin azurerm provider to 4.80.0

### DIFF
--- a/samples/terraform/authorization-permission-mismatch/main.tf
+++ b/samples/terraform/authorization-permission-mismatch/main.tf
@@ -1,4 +1,11 @@
-terraform {}
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "= 4.80.0"
+    }
+  }
+}
 
 provider "azurerm" {
   features {}


### PR DESCRIPTION
## Summary

- pin the `authorization-permission-mismatch` E2E sample to `hashicorp/azurerm` 4.80.0
- prevent clean E2E runs from automatically selecting 4.81.0
- use the merge-group E2E run to validate whether the provider update is related to the persistent failures

## Context

The last successful scheduled Terraform E2E run used azurerm 4.80.0. Persistent failures began when clean initialization started selecting 4.81.0. This pin is intentionally limited to the failing sample while the suspected provider behavior is investigated.

Relates to #311.

## Validation

- `terraform fmt -check samples/terraform/authorization-permission-mismatch/main.tf`
- `terraform init -backend=false -input=false` selected azurerm 4.80.0
