### PR TITLE
test: rotate Terraform E2E identities to reduce RBAC flakiness

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -99,6 +99,33 @@ jobs:
           tenant-id: ${{ secrets.MPF_TENANTID }}
           subscription-id: ${{ secrets.MPF_SUBSCRIPTIONID }}
 
+      - name: 🔎 Check Terraform credentials
+        if: runner.os == 'Linux' && matrix.type == 'terraform'
+        env:
+          MPF_SPCLIENTID: ${{ secrets.MPF_TERRAFORM_LINUX_SPCLIENTID }}
+          MPF_SPCLIENTSECRET: ${{ secrets.MPF_TERRAFORM_LINUX_SPCLIENTSECRET }}
+          MPF_SPOBJECTID: ${{ secrets.MPF_TERRAFORM_LINUX_SPOBJECTID }}
+          MPF_TERRAFORM_ALT_SPCLIENTID: ${{ secrets.MPF_TERRAFORM_LINUX_ALT_SPCLIENTID }}
+          MPF_TERRAFORM_ALT_SPCLIENTSECRET: ${{ secrets.MPF_TERRAFORM_LINUX_ALT_SPCLIENTSECRET }}
+          MPF_TERRAFORM_ALT_SPOBJECTID: ${{ secrets.MPF_TERRAFORM_LINUX_ALT_SPOBJECTID }}
+        run: |
+          test -n "${MPF_SPCLIENTID}" || { echo "::error::Missing MPF_TERRAFORM_LINUX_SPCLIENTID"; exit 1; }
+          test -n "${MPF_SPCLIENTSECRET}" || { echo "::error::Missing MPF_TERRAFORM_LINUX_SPCLIENTSECRET"; exit 1; }
+          test -n "${MPF_SPOBJECTID}" || { echo "::error::Missing MPF_TERRAFORM_LINUX_SPOBJECTID"; exit 1; }
+          test -n "${MPF_TERRAFORM_ALT_SPCLIENTID}" || { echo "::error::Missing MPF_TERRAFORM_LINUX_ALT_SPCLIENTID"; exit 1; }
+          test -n "${MPF_TERRAFORM_ALT_SPCLIENTSECRET}" || { echo "::error::Missing MPF_TERRAFORM_LINUX_ALT_SPCLIENTSECRET"; exit 1; }
+          test -n "${MPF_TERRAFORM_ALT_SPOBJECTID}" || { echo "::error::Missing MPF_TERRAFORM_LINUX_ALT_SPOBJECTID"; exit 1; }
+
+      - name: 🧪 Run terraform CLI Tests
+        if: runner.os == 'Linux' && matrix.type == 'terraform'
+        run: task testcli:terraform
+        env:
+          MPF_SUBSCRIPTIONID: ${{ secrets.MPF_SUBSCRIPTIONID }}
+          MPF_TENANTID: ${{ secrets.MPF_TENANTID }}
+          MPF_SPCLIENTID: ${{ secrets.MPF_TERRAFORM_LINUX_SPCLIENTID }}
+          MPF_SPCLIENTSECRET: ${{ secrets.MPF_TERRAFORM_LINUX_SPCLIENTSECRET }}
+          MPF_SPOBJECTID: ${{ secrets.MPF_TERRAFORM_LINUX_SPOBJECTID }}
+
       - name: 🧪 Run ${{ matrix.type }} E2E Tests
         if: runner.os == 'Linux'
         run: task teste2e:${{ matrix.type }}
@@ -108,8 +135,12 @@ jobs:
           MPF_SPCLIENTID: ${{ matrix.type == 'terraform' && secrets[format('MPF_TERRAFORM_{0}_SPCLIENTID', runner.os == 'Windows' && 'WINDOWS' || 'LINUX')] || matrix.type == 'arm' && secrets[format('MPF_ARM_{0}_SPCLIENTID', runner.os == 'Windows' && 'WINDOWS' || 'LINUX')] || secrets[format('MPF_BICEP_{0}_SPCLIENTID', runner.os == 'Windows' && 'WINDOWS' || 'LINUX')] }}
           MPF_SPCLIENTSECRET: ${{ matrix.type == 'terraform' && secrets[format('MPF_TERRAFORM_{0}_SPCLIENTSECRET', runner.os == 'Windows' && 'WINDOWS' || 'LINUX')] || matrix.type == 'arm' && secrets[format('MPF_ARM_{0}_SPCLIENTSECRET', runner.os == 'Windows' && 'WINDOWS' || 'LINUX')] || secrets[format('MPF_BICEP_{0}_SPCLIENTSECRET', runner.os == 'Windows' && 'WINDOWS' || 'LINUX')] }}
           MPF_SPOBJECTID: ${{ matrix.type == 'terraform' && secrets[format('MPF_TERRAFORM_{0}_SPOBJECTID', runner.os == 'Windows' && 'WINDOWS' || 'LINUX')] || matrix.type == 'arm' && secrets[format('MPF_ARM_{0}_SPOBJECTID', runner.os == 'Windows' && 'WINDOWS' || 'LINUX')] || secrets[format('MPF_BICEP_{0}_SPOBJECTID', runner.os == 'Windows' && 'WINDOWS' || 'LINUX')] }}
+          MPF_TERRAFORM_ALT_SPCLIENTID: ${{ matrix.type == 'terraform' && secrets.MPF_TERRAFORM_LINUX_ALT_SPCLIENTID || '' }}
+          MPF_TERRAFORM_ALT_SPCLIENTSECRET: ${{ matrix.type == 'terraform' && secrets.MPF_TERRAFORM_LINUX_ALT_SPCLIENTSECRET || '' }}
+          MPF_TERRAFORM_ALT_SPOBJECTID: ${{ matrix.type == 'terraform' && secrets.MPF_TERRAFORM_LINUX_ALT_SPOBJECTID || '' }}
 
       - name: 🧪 Run ${{ matrix.type }} CLI Tests
+        if: runner.os != 'Linux' || matrix.type != 'terraform'
         run: task testcli:${{ matrix.type }}
         env:
           MPF_SUBSCRIPTIONID: ${{ secrets.MPF_SUBSCRIPTIONID }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -233,6 +233,7 @@ tasks:
     cmds:
       # yamllint disable-line rule:quoted-strings
       - 'gotestsum --format-hivis --format {{.FORMAT}} --jsonfile "testresults.json" ./pkg/domain ./pkg/infrastructure/ARMTemplateShared ./pkg/infrastructure/mpfSharedUtils ./pkg/infrastructure/authorizationCheckers/terraform -p {{numCPU}} -timeout 5m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
+      - go test ./e2eTests -run TestE2EIdentitySelector -count=1
       - task: _test:getcover
     vars:
       TEST_NAME: "{{if gt (len (splitArgs .CLI_ARGS)) 0}}{{index (splitArgs .CLI_ARGS) 0}}{{end}}"

--- a/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
+++ b/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
@@ -41,7 +41,7 @@ import (
 func TestTerraformAuthorizationPermissionMismatch(t *testing.T) {
 	// import errors can occur for some resources, when identity does not have all required permissions,
 	// as described in https://github.com/hashicorp/terraform-provider-azurerm/issues/27961#issuecomment-2467392936
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}

--- a/e2eTests/e2eTerraformAuthorizationRequestDenied_test.go
+++ b/e2eTests/e2eTerraformAuthorizationRequestDenied_test.go
@@ -43,7 +43,7 @@ import (
 // cannot auto-discover. MPF should fail with a clear guidance error instead of
 // silently looping or producing a misleading parse error.
 func TestTerraformAuthorizationRequestDenied(t *testing.T) {
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}

--- a/e2eTests/e2eTerraformIdentity_test.go
+++ b/e2eTests/e2eTerraformIdentity_test.go
@@ -1,0 +1,148 @@
+// MIT License
+//
+// Copyright (c) Microsoft Corporation.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package e2etests
+
+import (
+	"errors"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	terraformAltSPClientIDEnv     = "MPF_TERRAFORM_ALT_SPCLIENTID"
+	terraformAltSPClientSecretEnv = "MPF_TERRAFORM_ALT_SPCLIENTSECRET"
+	terraformAltSPObjectIDEnv     = "MPF_TERRAFORM_ALT_SPOBJECTID"
+)
+
+var terraformIdentitySequence atomic.Uint64
+var errMissingAlternateTerraformCredentials = errors.New("required alternate Terraform service principal environment variables not set")
+
+func getTestingTerraformMPFArgs(t *testing.T) (MpfCLIArgs, error) {
+	t.Helper()
+
+	mpfArgs, err := getTestingMPFArgs()
+	if err != nil {
+		return MpfCLIArgs{}, err
+	}
+
+	slot := terraformIdentitySequence.Add(1)
+	mpfArgs, identity, err := selectTerraformIdentity(mpfArgs, slot)
+	if err != nil {
+		t.Fatalf("selecting Terraform E2E identity: %v", err)
+	}
+	log.Infof("Terraform E2E identity for %s: %s", t.Name(), identity)
+
+	return mpfArgs, nil
+}
+
+func selectTerraformIdentity(mpfArgs MpfCLIArgs, slot uint64) (MpfCLIArgs, string, error) {
+	if slot%2 == 0 {
+		return mpfArgs, "primary", nil
+	}
+
+	clientID := os.Getenv(terraformAltSPClientIDEnv)
+	clientSecret := os.Getenv(terraformAltSPClientSecretEnv)
+	objectID := os.Getenv(terraformAltSPObjectIDEnv)
+	if clientID == "" && clientSecret == "" && objectID == "" {
+		return mpfArgs, "primary (alternate not configured)", nil
+	}
+	if clientID == "" || clientSecret == "" || objectID == "" {
+		return MpfCLIArgs{}, "", errMissingAlternateTerraformCredentials
+	}
+
+	mpfArgs.SPClientID = clientID
+	mpfArgs.SPClientSecret = clientSecret
+	mpfArgs.SPObjectID = objectID
+
+	return mpfArgs, "alternate", nil
+}
+
+func TestE2EIdentitySelectorAlternates(t *testing.T) {
+	t.Setenv(terraformAltSPClientIDEnv, "alternate-client")
+	t.Setenv(terraformAltSPClientSecretEnv, "alternate-secret")
+	t.Setenv(terraformAltSPObjectIDEnv, "alternate-object")
+	primary := MpfCLIArgs{
+		SPClientID:     "primary-client",
+		SPClientSecret: "primary-secret",
+		SPObjectID:     "primary-object",
+	}
+
+	alternate, identity, err := selectTerraformIdentity(primary, 1)
+	if err != nil {
+		t.Fatalf("selecting alternate identity: %v", err)
+	}
+	if identity != "alternate" ||
+		alternate.SPClientID != "alternate-client" ||
+		alternate.SPClientSecret != "alternate-secret" ||
+		alternate.SPObjectID != "alternate-object" {
+		t.Fatalf("unexpected alternate identity: slot=%q client=%q object=%q", identity, alternate.SPClientID, alternate.SPObjectID)
+	}
+
+	selectedPrimary, identity, err := selectTerraformIdentity(primary, 2)
+	if err != nil {
+		t.Fatalf("selecting primary identity: %v", err)
+	}
+	if identity != "primary" ||
+		selectedPrimary.SPClientID != "primary-client" ||
+		selectedPrimary.SPClientSecret != "primary-secret" ||
+		selectedPrimary.SPObjectID != "primary-object" {
+		t.Fatalf("unexpected primary identity: slot=%q client=%q object=%q", identity, selectedPrimary.SPClientID, selectedPrimary.SPObjectID)
+	}
+
+	alternateAgain, identity, err := selectTerraformIdentity(primary, 3)
+	if err != nil {
+		t.Fatalf("selecting alternate identity again: %v", err)
+	}
+	if identity != "alternate" || alternateAgain.SPClientID != "alternate-client" {
+		t.Fatalf("expected selector to return to alternate identity, got slot=%q client=%q", identity, alternateAgain.SPClientID)
+	}
+}
+
+func TestE2EIdentitySelectorRejectsIncompleteAlternateCredentials(t *testing.T) {
+	t.Setenv(terraformAltSPClientIDEnv, "alternate-client")
+	t.Setenv(terraformAltSPClientSecretEnv, "")
+	t.Setenv(terraformAltSPObjectIDEnv, "")
+
+	_, _, err := selectTerraformIdentity(MpfCLIArgs{}, 1)
+	if !errors.Is(err, errMissingAlternateTerraformCredentials) {
+		t.Fatalf("expected missing alternate credentials error, got %v", err)
+	}
+}
+
+func TestE2EIdentitySelectorFallsBackWhenAlternateIsNotConfigured(t *testing.T) {
+	t.Setenv(terraformAltSPClientIDEnv, "")
+	t.Setenv(terraformAltSPClientSecretEnv, "")
+	t.Setenv(terraformAltSPObjectIDEnv, "")
+	primary := MpfCLIArgs{SPClientID: "primary-client"}
+
+	mpfArgs, identity, err := selectTerraformIdentity(primary, 1)
+	if err != nil {
+		t.Fatalf("selecting fallback identity: %v", err)
+	}
+	if identity != "primary (alternate not configured)" || mpfArgs.SPClientID != "primary-client" {
+		t.Fatalf("expected primary fallback identity, got slot=%q client=%q", identity, mpfArgs.SPClientID)
+	}
+}

--- a/e2eTests/e2eTerraformInvalid_test.go
+++ b/e2eTests/e2eTerraformInvalid_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestTerraformACIInvalidVarFile(t *testing.T) {
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}
@@ -85,7 +85,7 @@ func TestTerraformACIInvalidVarFile(t *testing.T) {
 }
 
 func TestTerraformACIInvalidTfFile(t *testing.T) {
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}
@@ -130,7 +130,7 @@ func TestTerraformACIInvalidTfFile(t *testing.T) {
 }
 
 func TestTerraformACIInvalidTfExec(t *testing.T) {
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}

--- a/e2eTests/e2eTerraformWithImportAndTargeting_test.go
+++ b/e2eTests/e2eTerraformWithImportAndTargeting_test.go
@@ -39,7 +39,7 @@ import (
 func TestTerraformWithImport(t *testing.T) {
 	// import errors can occur for some resources, when identity does not have all required permissions,
 	// as described in https://github.com/hashicorp/terraform-provider-azurerm/issues/27961#issuecomment-2467392936
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}
@@ -90,7 +90,7 @@ func TestTerraformWithImport(t *testing.T) {
 func TestTerraformWithTargetting(t *testing.T) {
 	// import errors can occur for some resources, when identity does not have all required permissions,
 	// as described in https://github.com/hashicorp/terraform-provider-azurerm/issues/27961#issuecomment-2467392936
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}

--- a/e2eTests/e2eTerraform_test.go
+++ b/e2eTests/e2eTerraform_test.go
@@ -66,7 +66,7 @@ func cleanTerraformWorkingDir(t *testing.T, workingDir string) {
 }
 
 func TestTerraformACI(t *testing.T) {
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}
@@ -119,7 +119,7 @@ func TestTerraformACI(t *testing.T) {
 }
 
 func TestTerraformACINoTfvarsFile(t *testing.T) {
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}
@@ -169,7 +169,7 @@ func TestTerraformACINoTfvarsFile(t *testing.T) {
 }
 
 func TestTerraformModuleTest(t *testing.T) {
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}
@@ -301,7 +301,7 @@ func TestTerraformModuleTest(t *testing.T) {
 // This validates the --initialPermissions flag feature (issue #91) which reduces execution time
 // by seeding known permissions.
 func TestTerraformACIWithInitialPermissions(t *testing.T) {
-	mpfArgs, err := getTestingMPFArgs()
+	mpfArgs, err := getTestingTerraformMPFArgs(t)
 	if err != nil {
 		t.Skip("required environment variables not set, skipping end to end test")
 	}

--- a/pkg/usecase/mpfService.go
+++ b/pkg/usecase/mpfService.go
@@ -107,9 +107,9 @@ func (s *MPFService) GetMinimumPermissionsRequired() (domain.MPFResult, error) {
 	log.Info("Deleted all existing role assignments for service principal \n")
 
 	// Wait for Azure RBAC propagation after deleting role assignments
-	// This ensures that any previous permissions are fully revoked before starting the new test
+	// This gives previously granted permissions time to be revoked before discovery starts.
 	log.Infoln("Waiting for Azure RBAC propagation after deleting role assignments...")
-	time.Sleep(45 * time.Second)
+	time.Sleep(15 * time.Second)
 
 	// Initialize new custom role
 	log.Infoln("Initializing Custom Role")

--- a/pkg/usecase/mpfService.go
+++ b/pkg/usecase/mpfService.go
@@ -109,7 +109,7 @@ func (s *MPFService) GetMinimumPermissionsRequired() (domain.MPFResult, error) {
 	// Wait for Azure RBAC propagation after deleting role assignments
 	// This gives previously granted permissions time to be revoked before discovery starts.
 	log.Infoln("Waiting for Azure RBAC propagation after deleting role assignments...")
-	time.Sleep(15 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	// Initialize new custom role
 	log.Infoln("Initializing Custom Role")

--- a/scripts/create-e2e-service-principals.ps1
+++ b/scripts/create-e2e-service-principals.ps1
@@ -11,6 +11,16 @@ Uses a small in-script matrix (ecosystem × OS) to create/reuse principals dynam
 param(
     [switch] $Yes,
     [switch] $AddToGitHub,
+    [ValidateSet(
+        'terraform_linux',
+        'terraform_windows',
+        'arm_linux',
+        'arm_windows',
+        'bicep_linux',
+        'bicep_windows',
+        'terraform_linux_alt'
+    )]
+    [string[]] $Target,
     [string] $OutputFile = 'e2e-service-principals.json'
 )
 
@@ -26,16 +36,22 @@ function To-TitleCase([string]$s) {
     return (Get-Culture).TextInfo.ToTitleCase($s)
 }
 
-function Get-SpName([string]$ecosystem, [string]$os) {
-    return "mpf-$ecosystem-$os-e2e-sp"
+function Get-SpName([string]$ecosystem, [string]$os, [string]$variant) {
+    $variantSuffix = if ($variant) { "-$variant" } else { '' }
+    return "mpf-$ecosystem-$os$variantSuffix-e2e-sp"
 }
 
-function Get-Label([string]$ecosystem, [string]$os) {
-    return "MPF $(To-TitleCase $ecosystem) $(To-TitleCase $os) E2E"
+function Get-Label([string]$ecosystem, [string]$os, [string]$variant) {
+    $variantLabel = if ($variant) { " $(To-TitleCase $variant)" } else { '' }
+    return "MPF $(To-TitleCase $ecosystem) $(To-TitleCase $os)$variantLabel E2E"
 }
 
-function Get-SecretPrefix([string]$ecosystem, [string]$os) {
-    return "MPF_$($ecosystem.ToUpperInvariant())_$($os.ToUpperInvariant())"
+function Get-SecretPrefix([string]$key) {
+    return "MPF_$($key.ToUpperInvariant())"
+}
+
+if ($Target -and (Test-Path -LiteralPath $OutputFile)) {
+    throw "Targeted provisioning will not overwrite existing output file: $OutputFile. Choose a new path with -OutputFile."
 }
 
 if (-not (Get-Command az -ErrorAction SilentlyContinue)) { throw 'az not found. Install Azure CLI: https://learn.microsoft.com/cli/azure/install-azure-cli' }
@@ -179,8 +195,23 @@ $ecosystems = @('terraform', 'arm', 'bicep')
 $oses = @('linux', 'windows')
 $matrix = foreach ($ecosystem in $ecosystems) {
     foreach ($os in $oses) {
-        [pscustomobject]@{ ecosystem = $ecosystem; os = $os }
+        [pscustomobject]@{
+            key       = "${ecosystem}_${os}"
+            ecosystem = $ecosystem
+            os        = $os
+            variant   = ''
+        }
     }
+}
+$matrix += [pscustomobject]@{
+    key       = 'terraform_linux_alt'
+    ecosystem = 'terraform'
+    os        = 'linux'
+    variant   = 'alt'
+}
+
+if ($Target) {
+    $matrix = @($matrix | Where-Object { $_.key -in $Target })
 }
 
 Info "Creating service principals for E2E tests ($($matrix.Count) total)..."
@@ -188,9 +219,9 @@ Write-Host ""
 
 $servicePrincipals = @{}
 foreach ($m in $matrix) {
-    $spName = Get-SpName -ecosystem $m.ecosystem -os $m.os
-    $label = Get-Label -ecosystem $m.ecosystem -os $m.os
-    $key = "$($m.ecosystem)_$($m.os)"
+    $spName = Get-SpName -ecosystem $m.ecosystem -os $m.os -variant $m.variant
+    $label = Get-Label -ecosystem $m.ecosystem -os $m.os -variant $m.variant
+    $key = $m.key
     $servicePrincipals[$key] = New-Sp $spName $label
     Write-Host ""
 }
@@ -201,7 +232,7 @@ Write-Host ""
 Info "Saving credentials to $($OutputFile)"
 $payload = [ordered]@{}
 foreach ($m in $matrix) {
-    $key = "$($m.ecosystem)_$($m.os)"
+    $key = $m.key
     $sp = $servicePrincipals[$key]
     $payload[$key] = [ordered]@{ client_id = $sp.ClientId; client_secret = $sp.ClientSecret; object_id = $sp.ObjectId }
 }
@@ -225,8 +256,8 @@ if ($shouldAddToGitHub) {
     $env:GH_REPO = $repoName
 
     foreach ($m in $matrix) {
-        $key = "$($m.ecosystem)_$($m.os)"
-        $prefix = Get-SecretPrefix -ecosystem $m.ecosystem -os $m.os
+        $key = $m.key
+        $prefix = Get-SecretPrefix -key $key
         Set-GitHubSecrets -RepoName $repoName -Prefix $prefix -Sp $servicePrincipals[$key]
     }
 
@@ -243,8 +274,8 @@ else {
     Write-Host ''
 
     foreach ($m in $matrix) {
-        $key = "$($m.ecosystem)_$($m.os)"
-        $prefix = Get-SecretPrefix -ecosystem $m.ecosystem -os $m.os
+        $key = $m.key
+        $prefix = Get-SecretPrefix -key $key
         $sp = $servicePrincipals[$key]
 
         # Do not print the full client secret to avoid leaking it via logs.

--- a/scripts/create-e2e-service-principals.sh
+++ b/scripts/create-e2e-service-principals.sh
@@ -7,12 +7,21 @@
 
 set -euo pipefail
 
-ECOSYSTEMS=("terraform" "arm" "bicep")
-OSES=("linux" "windows")
+TARGETS=(
+  "terraform_linux"
+  "terraform_windows"
+  "arm_linux"
+  "arm_windows"
+  "bicep_linux"
+  "bicep_windows"
+  "terraform_linux_alt"
+)
+SELECTED_TARGETS=()
+ACTIVE_TARGETS=()
 
-declare -A CLIENT_ID
-declare -A CLIENT_SECRET
-declare -A OBJECT_ID
+declare -a CLIENT_ID
+declare -a CLIENT_SECRET
+declare -a OBJECT_ID
 
 YES=false
 ADD_TO_GITHUB=""
@@ -51,6 +60,9 @@ Creates (or reuses) Entra ID app/service principals for MPF E2E tests and option
 Options:
   -y, --yes                Skip prompts (non-interactive). Defaults to NOT adding secrets to GitHub unless --add-to-github is set.
       --add-to-github      Automatically add secrets to GitHub repository.
+  -t, --target TARGET      Create only TARGET. May be repeated. Valid targets:
+                           terraform_linux, terraform_windows, arm_linux, arm_windows,
+                           bicep_linux, bicep_windows, terraform_linux_alt.
   -o, --output-file PATH   Output JSON file path (default: e2e-service-principals.json)
   -h, --help               Show this help.
 EOF
@@ -59,27 +71,35 @@ EOF
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -y | --yes)
-        YES=true
-        shift
-        ;;
-      --add-to-github)
-        ADD_TO_GITHUB=true
-        shift
-        ;;
-      -o | --output-file)
-        OUTPUT_FILE="$2"
-        shift 2
-        ;;
-      -h | --help)
-        usage
-        exit 0
-        ;;
-      *)
-        print_error "Unknown argument: $1"
-        usage
+    -y | --yes)
+      YES=true
+      shift
+      ;;
+    --add-to-github)
+      ADD_TO_GITHUB=true
+      shift
+      ;;
+    -t | --target)
+      if [[ $# -lt 2 ]]; then
+        print_error "$1 requires a target"
         exit 2
-        ;;
+      fi
+      SELECTED_TARGETS+=("$2")
+      shift 2
+      ;;
+    -o | --output-file)
+      OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      print_error "Unknown argument: $1"
+      usage
+      exit 2
+      ;;
     esac
   done
 
@@ -89,6 +109,36 @@ parse_args() {
 
   if [[ -z "${ADD_TO_GITHUB}" ]]; then
     ADD_TO_GITHUB=""
+  fi
+
+  if [[ ${#SELECTED_TARGETS[@]} -eq 0 ]]; then
+    ACTIVE_TARGETS=("${TARGETS[@]}")
+    return
+  fi
+
+  local selected
+  local valid
+  for selected in "${SELECTED_TARGETS[@]}"; do
+    valid=false
+    local target
+    for target in "${TARGETS[@]}"; do
+      if [[ "${selected}" == "${target}" ]]; then
+        valid=true
+        break
+      fi
+    done
+    if [[ "${valid}" != true ]]; then
+      print_error "Unknown target: ${selected}"
+      usage
+      exit 2
+    fi
+    ACTIVE_TARGETS+=("${selected}")
+  done
+
+  if [[ -e "${OUTPUT_FILE}" ]]; then
+    print_error "Targeted provisioning will not overwrite existing output file: ${OUTPUT_FILE}"
+    print_error "Choose a new path with --output-file."
+    exit 2
   fi
 }
 
@@ -146,13 +196,17 @@ check_prerequisites() {
 }
 
 create_service_principal() {
-  local ecosystem="$1"
-  local os="$2"
+  local index="$1"
+  local key="$2"
+  local ecosystem
+  local os
+  local variant
+  IFS="_" read -r ecosystem os variant <<<"${key}"
 
   local sp_name
-  sp_name="mpf-${ecosystem}-${os}-e2e-sp"
+  sp_name="mpf-${ecosystem}-${os}${variant:+-${variant}}-e2e-sp"
   local display_name
-  display_name="MPF $(title_case "${ecosystem}") $(title_case "${os}") E2E"
+  display_name="MPF $(title_case "${ecosystem}") $(title_case "${os}")${variant:+ $(title_case "${variant}")} E2E"
 
   print_status "Creating service principal: ${display_name}"
 
@@ -202,11 +256,9 @@ create_service_principal() {
     exit 1
   fi
 
-  local key
-  key="${ecosystem}_${os}"
-  CLIENT_ID["${key}"]="${app_id}"
-  CLIENT_SECRET["${key}"]="${password}"
-  OBJECT_ID["${key}"]="${object_id}"
+  CLIENT_ID["${index}"]="${app_id}"
+  CLIENT_SECRET["${index}"]="${password}"
+  OBJECT_ID["${index}"]="${object_id}"
 
   print_success "Created service principal: ${display_name}"
   print_status "  App ID: ${app_id}"
@@ -226,18 +278,16 @@ add_github_secrets() {
   # Additionally, we export GH_REPO so any subsequent gh commands inherit the context.
   export GH_REPO="${repo_name}"
 
-  for ecosystem in "${ECOSYSTEMS[@]}"; do
-    for os in "${OSES[@]}"; do
-      local key
-      key="${ecosystem}_${os}"
-      local prefix
-      prefix="MPF_${ecosystem^^}_${os^^}"
+  local index
+  for ((index = 0; index < ${#ACTIVE_TARGETS[@]}; index++)); do
+    local key="${ACTIVE_TARGETS[$index]}"
+    local prefix
+    prefix="MPF_$(echo "${key}" | tr '[:lower:]' '[:upper:]')"
 
-      print_status "Setting secrets for ${ecosystem} ${os}..."
-      echo "${CLIENT_ID[$key]}" | gh secret set "${prefix}_SPCLIENTID" -R "${repo_name}"
-      echo "${CLIENT_SECRET[$key]}" | gh secret set "${prefix}_SPCLIENTSECRET" -R "${repo_name}"
-      echo "${OBJECT_ID[$key]}" | gh secret set "${prefix}_SPOBJECTID" -R "${repo_name}"
-    done
+    print_status "Setting secrets for ${key//_/ }..."
+    echo "${CLIENT_ID[$index]}" | gh secret set "${prefix}_SPCLIENTID" -R "${repo_name}"
+    echo "${CLIENT_SECRET[$index]}" | gh secret set "${prefix}_SPCLIENTSECRET" -R "${repo_name}"
+    echo "${OBJECT_ID[$index]}" | gh secret set "${prefix}_SPOBJECTID" -R "${repo_name}"
   done
 
   print_status "Setting shared secrets (tenant/subscription)..."
@@ -254,27 +304,25 @@ display_github_secrets() {
   echo "Add the following secrets to your GitHub repository:"
   echo ""
 
-  for ecosystem in "${ECOSYSTEMS[@]}"; do
-    for os in "${OSES[@]}"; do
-      local key
-      key="${ecosystem}_${os}"
-      local prefix
-      prefix="MPF_${ecosystem^^}_${os^^}"
+  local index
+  for ((index = 0; index < ${#ACTIVE_TARGETS[@]}; index++)); do
+    local key="${ACTIVE_TARGETS[$index]}"
+    local prefix
+    prefix="MPF_$(echo "${key}" | tr '[:lower:]' '[:upper:]')"
 
-      # Mask client secret to avoid leaking it via logs
-      local client_secret="${CLIENT_SECRET[$key]}"
-      local client_secret_display
-      if [[ ${#client_secret} -gt 8 ]]; then
-        client_secret_display="${client_secret:0:4}...${client_secret: -4}"
-      else
-        client_secret_display="<redacted>"
-      fi
+    # Mask client secret to avoid leaking it via logs
+    local client_secret="${CLIENT_SECRET[$index]}"
+    local client_secret_display
+    if [[ ${#client_secret} -gt 8 ]]; then
+      client_secret_display="${client_secret:0:4}...${client_secret: -4}"
+    else
+      client_secret_display="<redacted>"
+    fi
 
-      echo "${prefix}_SPCLIENTID = ${CLIENT_ID[$key]}"
-      echo "${prefix}_SPCLIENTSECRET = ${client_secret_display} (full value stored securely in ${OUTPUT_FILE})"
-      echo "${prefix}_SPOBJECTID = ${OBJECT_ID[$key]}"
-      echo ""
-    done
+    echo "${prefix}_SPCLIENTID = ${CLIENT_ID[$index]}"
+    echo "${prefix}_SPCLIENTSECRET = ${client_secret_display} (full value stored securely in ${OUTPUT_FILE})"
+    echo "${prefix}_SPOBJECTID = ${OBJECT_ID[$index]}"
+    echo ""
   done
 
   echo ""
@@ -287,16 +335,14 @@ save_credentials() {
   print_status "Saving credentials to ${OUTPUT_FILE}"
 
   {
-    for ecosystem in "${ECOSYSTEMS[@]}"; do
-      for os in "${OSES[@]}"; do
-        local key
-        key="${ecosystem}_${os}"
-        printf "%s\t%s\t%s\t%s\n" \
-          "${key}" \
-          "${CLIENT_ID[$key]}" \
-          "${CLIENT_SECRET[$key]}" \
-          "${OBJECT_ID[$key]}"
-      done
+    local index
+    for ((index = 0; index < ${#ACTIVE_TARGETS[@]}; index++)); do
+      local key="${ACTIVE_TARGETS[$index]}"
+      printf "%s\t%s\t%s\t%s\n" \
+        "${key}" \
+        "${CLIENT_ID[$index]}" \
+        "${CLIENT_SECRET[$index]}" \
+        "${OBJECT_ID[$index]}"
     done
   } | jq -Rn --arg tenant "${TENANT_ID}" --arg sub "${SUBSCRIPTION_ID}" '
     reduce inputs as $line ({};
@@ -370,14 +416,13 @@ main() {
   fi
 
   # Create service principals
-  print_status "Creating service principals for E2E tests (${#ECOSYSTEMS[@]} ecosystems × ${#OSES[@]} OSes)..."
+  print_status "Creating service principals for E2E tests (${#ACTIVE_TARGETS[@]} targets)..."
   echo ""
 
-  for ecosystem in "${ECOSYSTEMS[@]}"; do
-    for os in "${OSES[@]}"; do
-      create_service_principal "${ecosystem}" "${os}"
-      echo ""
-    done
+  local index
+  for ((index = 0; index < ${#ACTIVE_TARGETS[@]}; index++)); do
+    create_service_principal "${index}" "${ACTIVE_TARGETS[$index]}"
+    echo ""
   done
 
   # Display results

--- a/scripts/create-e2e-service-principals.sh
+++ b/scripts/create-e2e-service-principals.sh
@@ -71,35 +71,35 @@ EOF
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-    -y | --yes)
-      YES=true
-      shift
-      ;;
-    --add-to-github)
-      ADD_TO_GITHUB=true
-      shift
-      ;;
-    -t | --target)
-      if [[ $# -lt 2 ]]; then
-        print_error "$1 requires a target"
+      -y | --yes)
+        YES=true
+        shift
+        ;;
+      --add-to-github)
+        ADD_TO_GITHUB=true
+        shift
+        ;;
+      -t | --target)
+        if [[ $# -lt 2 ]]; then
+          print_error "$1 requires a target"
+          exit 2
+        fi
+        SELECTED_TARGETS+=("$2")
+        shift 2
+        ;;
+      -o | --output-file)
+        OUTPUT_FILE="$2"
+        shift 2
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        print_error "Unknown argument: $1"
+        usage
         exit 2
-      fi
-      SELECTED_TARGETS+=("$2")
-      shift 2
-      ;;
-    -o | --output-file)
-      OUTPUT_FILE="$2"
-      shift 2
-      ;;
-    -h | --help)
-      usage
-      exit 0
-      ;;
-    *)
-      print_error "Unknown argument: $1"
-      usage
-      exit 2
-      ;;
+        ;;
     esac
   done
 


### PR DESCRIPTION
## Summary

Alternate the Linux Terraform E2E tests between two service principals to reduce stale Azure RBAC state carried between consecutive tests.

This change also:

- adds targeted provisioning for the alternate Terraform service principal;
- wires and validates the alternate credentials in the E2E workflow;
- preserves the existing single `gotestsum` process, test order, reporting, and failure aggregation;
- runs the Linux Terraform CLI test first with the primary identity;
- reduces the post-detachment propagation delay from 45 seconds to 1 second.

## Motivation

The Terraform E2E suite currently reuses one service principal across all tests. Azure role-assignment removal is eventually consistent, so permissions from one test can remain effective when the next test begins. This can cause permission discovery to depend on residual RBAC state and produce intermittent failures.

Using alternating identities gives each service principal additional recovery time while the other identity runs the next test. It also avoids applying a long fixed delay to every MPF invocation.

This work is related to #231, but does not close it. Azure RBAC propagation remains eventually consistent, and additional stabilization may still be needed for tests with exact permission assertions.

## Implementation

- Add `mpf-terraform-linux-alt-e2e-sp` as an alternate Linux Terraform identity.
- Select primary and alternate credentials using a concurrency-safe sequence in the Go E2E harness.
- Fall back to the primary identity for local runs when alternate credentials are entirely absent.
- Fail early when alternate credentials are only partially configured.
- Add workflow preflight checks for both Terraform identities.
- Add targeted `--target terraform_linux_alt` provisioning support to the Bash and PowerShell scripts.
- Prevent targeted provisioning from overwriting an existing credential output file.
- Keep ARM, Bicep, and Windows Terraform behavior unchanged.
- Retain the existing five-second waits after the initial role assignment and after each custom-role update.

## E2E results

The branch completed successfully with the original 15-second experiment and with the reduced one-second delay.

With the one-second delay:

- five full E2E workflow runs succeeded;
- the latest four spaced runs all completed successfully across every matrix job;
- one closely timed follow-up run failed because `TestTerraformAuthorizationPermissionMismatch` discovered the intermittent additional `Microsoft.Resources/subscriptions/providers/read` permission.

The isolated failure indicates that identity rotation reduces adjacent-test contamination but cannot completely eliminate Azure RBAC propagation variability across closely spaced workflow runs.

## Related issue

References #231.
