### PR TITLE
test: seed Terraform provider read permission

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -233,7 +233,7 @@ tasks:
     cmds:
       # yamllint disable-line rule:quoted-strings
       - 'gotestsum --format-hivis --format {{.FORMAT}} --jsonfile "testresults.json" ./pkg/domain ./pkg/infrastructure/ARMTemplateShared ./pkg/infrastructure/mpfSharedUtils ./pkg/infrastructure/authorizationCheckers/terraform -p {{numCPU}} -timeout 5m -ldflags="{{.LDFLAGS}}" -coverprofile="coverage.out" -covermode atomic'
-      - go test ./e2eTests -run TestE2EIdentitySelector -count=1
+      - go test ./e2eTests -run 'TestE2E(IdentitySelector|TerraformBootstrapPermissions)' -count=1
       - task: _test:getcover
     vars:
       TEST_NAME: "{{if gt (len (splitArgs .CLI_ARGS)) 0}}{{index (splitArgs .CLI_ARGS) 0}}{{end}}"

--- a/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
+++ b/e2eTests/e2eTerraformAuthPermissionMismatch_test.go
@@ -75,8 +75,7 @@ func TestTerraformAuthorizationPermissionMismatch(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, "", true, "")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 
@@ -86,5 +85,5 @@ func TestTerraformAuthorizationPermissionMismatch(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 11, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
+	assert.Equal(t, 12, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }

--- a/e2eTests/e2eTerraformAuthorizationRequestDenied_test.go
+++ b/e2eTests/e2eTerraformAuthorizationRequestDenied_test.go
@@ -71,8 +71,7 @@ func TestTerraformAuthorizationRequestDenied(t *testing.T) {
 	var rgManager usecase.ResourceGroupManager = rgm.NewResourceGroupManager(mpfArgs.SubscriptionID)
 	var spRoleAssignmentManager usecase.ServicePrincipalRolemAssignmentManager = spram.NewSPRoleAssignmentManager(mpfArgs.SubscriptionID)
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner := terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, "", true, "")
 	mpfService := usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 

--- a/e2eTests/e2eTerraformInvalid_test.go
+++ b/e2eTests/e2eTerraformInvalid_test.go
@@ -75,8 +75,7 @@ func TestTerraformACIInvalidVarFile(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, varsFile, true, "")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 
@@ -120,8 +119,7 @@ func TestTerraformACIInvalidTfFile(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, "", true, "")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 
@@ -161,8 +159,7 @@ func TestTerraformACIInvalidTfExec(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, "", true, "")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 

--- a/e2eTests/e2eTerraformPermissions_test.go
+++ b/e2eTests/e2eTerraformPermissions_test.go
@@ -1,0 +1,69 @@
+// MIT License
+//
+// Copyright (c) Microsoft Corporation.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package e2etests
+
+import (
+	"slices"
+	"testing"
+)
+
+const terraformProviderReadPermission = "Microsoft.Resources/subscriptions/providers/read"
+
+func getTerraformE2EBootstrapPermissions(additionalPermissions ...string) ([]string, []string) {
+	// AzureRM 3.x/4.x can list subscription providers while initializing its
+	// provider cache. Seed the permission so residual RBAC state cannot hide it.
+	initialPermissions := append([]string{
+		"Microsoft.Resources/deployments/read",
+		"Microsoft.Resources/deployments/write",
+		terraformProviderReadPermission,
+	}, additionalPermissions...)
+
+	return initialPermissions, slices.Clone(initialPermissions)
+}
+
+func TestE2ETerraformBootstrapPermissions(t *testing.T) {
+	expected := []string{
+		"Microsoft.Resources/deployments/read",
+		"Microsoft.Resources/deployments/write",
+		terraformProviderReadPermission,
+		"Microsoft.Test/widgets/read",
+	}
+
+	initialPermissions, resultPermissions := getTerraformE2EBootstrapPermissions("Microsoft.Test/widgets/read")
+	if !slices.Equal(initialPermissions, expected) {
+		t.Fatalf("unexpected initial permissions: %v", initialPermissions)
+	}
+	if !slices.Equal(resultPermissions, expected) {
+		t.Fatalf("unexpected result permissions: %v", resultPermissions)
+	}
+
+	initialPermissions[0] = "modified"
+	if resultPermissions[0] != expected[0] {
+		t.Fatal("initial and result permissions share a backing array")
+	}
+
+	nextInitialPermissions, _ := getTerraformE2EBootstrapPermissions("Microsoft.Test/widgets/read")
+	if !slices.Equal(nextInitialPermissions, expected) {
+		t.Fatalf("helper result was mutated across calls: %v", nextInitialPermissions)
+	}
+}

--- a/e2eTests/e2eTerraformWithImportAndTargeting_test.go
+++ b/e2eTests/e2eTerraformWithImportAndTargeting_test.go
@@ -73,8 +73,7 @@ func TestTerraformWithImport(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, "", true, "")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 
@@ -84,7 +83,7 @@ func TestTerraformWithImport(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 17, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
+	assert.Equal(t, 18, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }
 
 func TestTerraformWithTargetting(t *testing.T) {
@@ -124,8 +123,7 @@ func TestTerraformWithTargetting(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, "", true, "module.law")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 
@@ -135,5 +133,5 @@ func TestTerraformWithTargetting(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
+	assert.Equal(t, 9, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }

--- a/e2eTests/e2eTerraform_test.go
+++ b/e2eTests/e2eTerraform_test.go
@@ -104,8 +104,7 @@ func TestTerraformACI(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, varsFile, true, "")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 
@@ -115,7 +114,7 @@ func TestTerraformACI(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
+	assert.Equal(t, 9, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }
 
 func TestTerraformACINoTfvarsFile(t *testing.T) {
@@ -154,8 +153,7 @@ func TestTerraformACINoTfvarsFile(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, "", true, "")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 
@@ -165,7 +163,7 @@ func TestTerraformACINoTfvarsFile(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
-	assert.Equal(t, 5, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
+	assert.Equal(t, 6, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }
 
 func TestTerraformModuleTest(t *testing.T) {
@@ -204,8 +202,7 @@ func TestTerraformModuleTest(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	initialPermissionsToAdd := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
-	permissionsToAddToResult := []string{"Microsoft.Resources/deployments/read", "Microsoft.Resources/deployments/write"}
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions()
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, "", true, "")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
 
@@ -219,6 +216,7 @@ func TestTerraformModuleTest(t *testing.T) {
 	// Microsoft.OperationalInsights/workspaces/write
 	// Microsoft.Resources/deployments/read
 	// Microsoft.Resources/deployments/write
+	// Microsoft.Resources/subscriptions/providers/read
 	// Microsoft.Resources/subscriptions/resourcegroups/delete
 	// Microsoft.Resources/subscriptions/resourcegroups/read
 	// Microsoft.Resources/subscriptions/resourcegroups/write
@@ -226,7 +224,7 @@ func TestTerraformModuleTest(t *testing.T) {
 	assert.NotEmpty(t, mpfResult.RequiredPermissions)
 	perms := mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]
 	log.Infof("Found %d permissions: %v", len(perms), perms)
-	assert.Equal(t, 8, len(perms))
+	assert.Equal(t, 9, len(perms))
 }
 
 //
@@ -338,11 +336,9 @@ func TestTerraformACIWithInitialPermissions(t *testing.T) {
 	var deploymentAuthorizationCheckerCleaner usecase.DeploymentAuthorizationCheckerCleaner
 	var mpfService *usecase.MPFService
 
-	// Provide ALL expected permissions upfront - this should result in 0 iterations
-	// These are the 8 permissions required for the ACI sample (from TestTerraformACI)
-	initialPermissionsToAdd := []string{
-		"Microsoft.Resources/deployments/read",
-		"Microsoft.Resources/deployments/write",
+	// Provide ALL expected permissions upfront - this should result in 0 iterations.
+	// These are the 9 permissions required for the ACI sample (from TestTerraformACI).
+	initialPermissionsToAdd, permissionsToAddToResult := getTerraformE2EBootstrapPermissions(
 		// ACI permissions
 		"Microsoft.ContainerInstance/containerGroups/read",
 		"Microsoft.ContainerInstance/containerGroups/write",
@@ -351,8 +347,7 @@ func TestTerraformACIWithInitialPermissions(t *testing.T) {
 		"Microsoft.Resources/subscriptions/resourcegroups/read",
 		"Microsoft.Resources/subscriptions/resourcegroups/write",
 		"Microsoft.Resources/subscriptions/resourcegroups/delete",
-	}
-	permissionsToAddToResult := initialPermissionsToAdd
+	)
 
 	deploymentAuthorizationCheckerCleaner = terraform.NewTerraformAuthorizationChecker(wrkDir, tfpath, varsFile, true, "")
 	mpfService = usecase.NewMPFService(ctx, rgManager, spRoleAssignmentManager, deploymentAuthorizationCheckerCleaner, mpfConfig, initialPermissionsToAdd, permissionsToAddToResult, false, true, false)
@@ -369,6 +364,6 @@ func TestTerraformACIWithInitialPermissions(t *testing.T) {
 	// in 0 iterations (no permission discovery needed)
 	assert.Equal(t, 0, mpfResult.IterationCount, "Expected 0 iterations when all permissions are provided upfront")
 
-	// Verify we have all 8 expected permissions
-	assert.Equal(t, 8, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
+	// Verify we have all 9 expected permissions
+	assert.Equal(t, 9, len(mpfResult.RequiredPermissions[mpfConfig.SubscriptionID]))
 }


### PR DESCRIPTION
## Summary

Seed `Microsoft.Resources/subscriptions/providers/read` as a bootstrap permission across the Terraform E2E suite and include it consistently in expected E2E results.

This makes Terraform permission-count assertions independent of whether AzureRM's resource-provider cache request is temporarily authorized by residual RBAC state.

## Background

AzureRM 3.x and 4.x can initialize their resource-provider cache by calling:

```text
GET /subscriptions/{subscriptionId}/providers
```

This maps to:

```text
Microsoft.Resources/subscriptions/providers/read
```

The call predates #328 and was observed in failures both before and after service-principal rotation. Post-merge runs also showed the permission affecting both the primary and alternate Terraform identities, so workflow spacing and identity rotation do not make the current exact permission counts deterministic.

## Changes

- Add a shared Terraform E2E bootstrap-permission helper containing:
  - `Microsoft.Resources/deployments/read`
  - `Microsoft.Resources/deployments/write`
  - `Microsoft.Resources/subscriptions/providers/read`
- Use the shared bootstrap permissions in all 11 active Terraform E2E paths.
- Return independent initial/result slices to avoid accidental shared mutation.
- Update the seven affected numeric result expectations by one.
- Preserve the zero-iteration assertion in `TestTerraformACIWithInitialPermissions` with all nine permissions supplied initially.
- Add focused unit coverage for helper contents and slice independence.

## Scope

This change is intentionally limited to Terraform E2E setup and assertions. It does not change:

- `cmd/terraformCmd.go` or production MPF output;
- AzureRM provider versions or sample provider configuration;
- ARM or Bicep tests;
- service-principal rotation or workflow orchestration;
- RBAC propagation delays.

Production Terraform runs continue to discover this permission dynamically when the selected AzureRM version and configuration require it. This avoids unconditionally reporting the permission for AzureRM configurations, such as newer 5.x defaults, that may not perform the provider-cache listing.

## Validation

- E2E package compile-only validation completed without executing tests.
- Changed files have no IDE diagnostics or formatting errors.
- Full branch E2E workflow is running: [33163652106](https://github.com/Azure/mpf/actions/runs/33163652106).

## Related issue

References #231.
